### PR TITLE
Argument `custom_reference`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,4 +39,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3.9000

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,6 @@ Imports:
     fs,
     here,
     htmltools,
-    jsonlite,
     rmarkdown,
     rstudioapi,
     servr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,7 +18,11 @@
 * Vignettes are now always rendered by `use_*()` or `update_docs()`. Previously,
   they were only rendered if their content changed. This was problematic because
   the code in a vignette can have different output while the vignette in itself
-  doesn't change.
+  doesn't change (#37).
+  
+* New argument `custom_reference` in `use_*()` and `update_docs()`. If it is a
+  path to a custom R file then it uses this file to build the "Reference" section
+  in the docs (#35).
 
 
 

--- a/R/build.R
+++ b/R/build.R
@@ -93,14 +93,14 @@
 
 # Build docs and vignettes ---------------------
 
-.build_docs <- function(path = ".") {
+.build_docs <- function(path = ".", custom_reference = NULL) {
   cli::cli_h1("Docs structure")
   cli::cli_alert_success("Folder {.file docs} created.")
   .import_readme(path)
   .import_news(path)
   .import_coc(path)
   .import_license(path)
-  .make_reference(update = FALSE, path)
+  .make_reference(update = FALSE, path, custom_reference)
 }
 
 .build_vignettes <- function(convert_vignettes, path) {

--- a/R/reference.R
+++ b/R/reference.R
@@ -1,7 +1,19 @@
 # Convert and unite .Rd files to 'docs/reference.md'.
-.make_reference <- function(update = FALSE, path = ".") {
+.make_reference <- function(update = FALSE, path = ".",
+                            custom_reference = NULL) {
+
+  cli::cli_h1("Building reference")
+  if (!is.null(custom_reference)) {
+    cli::cli_progress_bar("{cli::pb_spin} Running file {.file {custom_reference}}")
+    source(custom_reference, echo = FALSE)
+    cli::cli_alert_success("Custom file for {.pkg Reference} finished running.")
+    return(invisible)
+  }
+
   good_path <- .doc_path(path = path)
-  if (fs::file_exists(paste0(good_path, "/reference.md"))) fs::file_delete(paste0(good_path, "/reference.md"))
+  if (fs::file_exists(paste0(good_path, "/reference.md"))) {
+    fs::file_delete(paste0(good_path, "/reference.md"))
+  }
 
   files <- list.files("man", full.names = TRUE)
   files <- files[grepl("\\.Rd", files)]

--- a/R/update.R
+++ b/R/update.R
@@ -7,6 +7,8 @@
 #' @param convert_vignettes Automatically convert and import vignettes if you
 #' have some. This will not modify files in the folder 'vignettes'.
 #' @param path Path. Default is the package root (detected with `here::here()`).
+#' @param custom_reference Path to the file that will be sourced to generate the
+#' "Reference" section.
 #'
 #' @export
 #'

--- a/R/update.R
+++ b/R/update.R
@@ -18,7 +18,8 @@
 #' update_docs()
 #' }
 
-update_docs <- function(convert_vignettes = TRUE, path = ".") {
+update_docs <- function(convert_vignettes = TRUE, path = ".",
+                        custom_reference = NULL) {
 
   path <- .convert_path(path)
 
@@ -50,7 +51,7 @@ update_docs <- function(convert_vignettes = TRUE, path = ".") {
   }
 
   # Update functions reference
-  .make_reference(update = TRUE, path)
+  .make_reference(update = TRUE, path, custom_reference)
 
   # Update vignettes
   if (isTRUE(convert_vignettes)) {

--- a/R/use.R
+++ b/R/use.R
@@ -6,6 +6,8 @@
 #' (default), there will be an interactive choice to make in the console to
 #' overwrite. If `TRUE`, the folder 'docs' is automatically overwritten.
 #' @param path Path. Default is the package root (detected with `here::here()`).
+#' @param custom_reference Path to the file that will be sourced to generate the
+#' "Reference" section.
 #'
 #' @export
 #'
@@ -26,14 +28,14 @@
 #' }
 
 use_docute <- function(convert_vignettes = TRUE, overwrite = FALSE,
-                       path = ".") {
+                       path = ".", custom_reference = NULL) {
 
   path <- .convert_path(path)
   .check_is_package(path)
   .check_docs_exists(overwrite, path)
 
   .create_index("docute", path)
-  .build_docs(path)
+  .build_docs(path, custom_reference)
   .build_vignettes(convert_vignettes, path)
 
   .final_steps(x = "docute", path)
@@ -44,7 +46,7 @@ use_docute <- function(convert_vignettes = TRUE, overwrite = FALSE,
 #' @rdname init
 
 use_docsify <- function(convert_vignettes = TRUE, overwrite = FALSE,
-                        path = ".") {
+                        path = ".", custom_reference = NULL) {
 
   path <- .convert_path(path)
   .check_is_package(path)
@@ -52,7 +54,7 @@ use_docsify <- function(convert_vignettes = TRUE, overwrite = FALSE,
 
   .create_index("docsify", path = path)
 
-  .build_docs(path = path)
+  .build_docs(path = path, custom_reference)
 
   fs::file_copy(
     system.file("docsify/_sidebar.md", package = "altdoc"),
@@ -70,10 +72,11 @@ use_docsify <- function(convert_vignettes = TRUE, overwrite = FALSE,
 #'
 #' @param theme Name of the theme to use. Default is basic theme. See Details
 #' section.
-#'
 #' @param convert_vignettes Do you want to convert and import vignettes if you have
 #' some? This will not modify files in the folder 'vignettes'. This feature
 #' is experimental.
+#' @param custom_reference Path to the file that will be sourced to generate the
+#' "Reference" section.
 #'
 #' @details
 #' If you are new to Mkdocs, the themes "readthedocs" and "material" are among
@@ -82,7 +85,8 @@ use_docsify <- function(convert_vignettes = TRUE, overwrite = FALSE,
 #' @rdname init
 
 use_mkdocs <- function(theme = NULL, convert_vignettes = TRUE,
-                       overwrite = FALSE, path = ".") {
+                       overwrite = FALSE, path = ".",
+                       custom_reference = NULL) {
 
   path <- .convert_path(path)
   .check_is_package(path)

--- a/R/utils.R
+++ b/R/utils.R
@@ -224,7 +224,7 @@
   people <- gsub("^ ", "", people)
 
   if (length(people) > 0) {
-    people_link <- paste0("https://github.com/", gsub(" @", "", people))
+    people_link <- paste0("https://github.com/", gsub("@", "", people))
 
     people_out <- data.frame(
       in_text = people,

--- a/man/init.Rd
+++ b/man/init.Rd
@@ -6,15 +6,26 @@
 \alias{use_mkdocs}
 \title{Init Docute, Docsify, or Mkdocs}
 \usage{
-use_docute(convert_vignettes = TRUE, overwrite = FALSE, path = ".")
+use_docute(
+  convert_vignettes = TRUE,
+  overwrite = FALSE,
+  path = ".",
+  custom_reference = NULL
+)
 
-use_docsify(convert_vignettes = TRUE, overwrite = FALSE, path = ".")
+use_docsify(
+  convert_vignettes = TRUE,
+  overwrite = FALSE,
+  path = ".",
+  custom_reference = NULL
+)
 
 use_mkdocs(
   theme = NULL,
   convert_vignettes = TRUE,
   overwrite = FALSE,
-  path = "."
+  path = ".",
+  custom_reference = NULL
 )
 }
 \arguments{
@@ -27,6 +38,9 @@ is experimental.}
 overwrite. If \code{TRUE}, the folder 'docs' is automatically overwritten.}
 
 \item{path}{Path. Default is the package root (detected with \code{here::here()}).}
+
+\item{custom_reference}{Path to the file that will be sourced to generate the
+"Reference" section.}
 
 \item{theme}{Name of the theme to use. Default is basic theme. See Details
 section.}

--- a/man/update_docs.Rd
+++ b/man/update_docs.Rd
@@ -4,7 +4,7 @@
 \alias{update_docs}
 \title{Update documentation}
 \usage{
-update_docs(convert_vignettes = TRUE, path = ".")
+update_docs(convert_vignettes = TRUE, path = ".", custom_reference = NULL)
 }
 \arguments{
 \item{convert_vignettes}{Automatically convert and import vignettes if you

--- a/man/update_docs.Rd
+++ b/man/update_docs.Rd
@@ -11,6 +11,9 @@ update_docs(convert_vignettes = TRUE, path = ".", custom_reference = NULL)
 have some. This will not modify files in the folder 'vignettes'.}
 
 \item{path}{Path. Default is the package root (detected with \code{here::here()}).}
+
+\item{custom_reference}{Path to the file that will be sourced to generate the
+"Reference" section.}
 }
 \value{
 No value returned. Updates files in folder 'docs'.


### PR DESCRIPTION
For projects where the reference section is very "non-standard", it allows us to use a custom script to build the reference section (used in `r-polars`)