### PR TITLE
Some fixes in vignettes handling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,12 +7,19 @@
   of their articles.
   
 
-### New features
-
+### Major changes
+  
 * `update_docs()` now updates the package version as well as altdoc version in 
   the footer.
+  
 * The NEWS or Changelog file included in the docs now automatically links issues,
   pull requests and users (only works for projects on Github).
+  
+* Vignettes are now always rendered by `use_*()` or `update_docs()`. Previously,
+  they were only rendered if their content changed. This was problematic because
+  the code in a vignette can have different output while the vignette in itself
+  doesn't change.
+
 
 
 # altdoc 0.1.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,19 @@
 # altdoc 0.1.0.9000 (development)
 
+### Breaking changes
+
+* Vignettes are no longer automatically added to the file that defines the structure
+  of the website. Developers must now manually update this structure and the order
+  of their articles.
+  
+
+### New features
+
 * `update_docs()` now updates the package version as well as altdoc version in 
   the footer.
 * The NEWS or Changelog file included in the docs now automatically links issues,
   pull requests and users (only works for projects on Github).
+
 
 # altdoc 0.1.0
 

--- a/R/vignettes.R
+++ b/R/vignettes.R
@@ -45,10 +45,6 @@
       fs::file_copy(origin, destination, overwrite = TRUE)
     }
   }
-  if (!any(vignette_is_different)) {
-    cli::cli_alert_info("No new vignette to convert.")
-    return(invisible())
-  }
 
   # needs to be first, otherwise compilation will fail
   .replace_figures_rmd()
@@ -153,36 +149,6 @@
 
   cli::cli_alert_info("The folder {.file {'vignettes'}} was not modified.")
 
-}
-
-
-# Check if vignettes in folder "vignettes" and in folder "docs/articles" differ
-#
-# Since the output of the vignette in the folder "vignette" is "html_vignette"
-# and the output of the vignette in the folder "docs/articles" is
-# "github_document", there will necessarily be changes. Therefore, the
-# comparison is made on the files without the YAML.
-#
-# @param x,y Names of the two vignettes to compare
-#
-# @return Boolean
-# @keywords internal
-
-.vignettes_differ <- function(x, y) {
-
-  if (!file.exists(x) | !file.exists(y)) {
-    return(TRUE)
-  }
-
-  x_file <- .readlines(x)
-  x_file <- x_file[-which(x_file == "")]
-  x_content <- gsub("---(.*?)---", "", paste(x_file, collapse = "\n"))
-
-  y_file <- .readlines(y)
-  y_file <- y_file[-which(y_file == "")]
-  y_content <- gsub("---(.*?)---", "", paste(y_file, collapse = "\n"))
-
-  return(!identical(x_content, y_content))
 }
 
 

--- a/R/vignettes.R
+++ b/R/vignettes.R
@@ -220,119 +220,22 @@
 # This creates a section "Articles" with every vignettes in docs/articles
 
 .add_vignettes <- function(path = path) {
-
   doctype <- .doc_type(path = path)
   vignettes_titles <- .get_vignettes_titles(path = path)
+
   if (is.null(vignettes_titles)) {
     return(invisible())
   }
-  if (!nrow(vignettes_titles) >= 1) {
-    return(invisible())
-  }
 
-  if (doctype == "docute") {
-
-    original_index <- .readlines(fs::path_abs("docs/index.html", start = path))
-
-    if (any(grepl("title: \"Articles\"", original_index))) {
-      cli::cli_alert_info("New vignettes were not added automatically in {.file {'docs/index.html'}}. You need to do it manually.")
-      return(invisible())
-    }
-
-    home_line <- which(grepl("\\{title: 'Home', link: '/'\\}", original_index))
-
-    original_index[home_line] <- paste0(
-      original_index[home_line],
-      "\n{
-					   title: \"Articles\",
-					   children:",
-      jsonlite::toJSON(vignettes_titles, pretty = TRUE),
-      "},\n"
-    )
-
-    writeLines(original_index, fs::path_abs("docs/index.html", start = path))
-
-  } else if (doctype == "docsify") {
-
-    original_sidebar <- .readlines(fs::path_abs("docs/_sidebar.md", start = path))
-
-    # Remove the articles / vignettes section to avoid duplicates
-    if (any(grepl("^\\* \\[Articles\\]\\(\\)", original_sidebar))) {
-      vignette_start <- grep("^\\* \\[Articles\\]\\(\\)", original_sidebar)
-      vignette_end <- grep("^\\* \\[", original_sidebar)
-      vignette_end <- vignette_end[vignette_end > vignette_start][1]-1
-      original_sidebar <- original_sidebar[-c(vignette_start:vignette_end)]
-    }
-
-    # Insert articles section just below home
-    home_line <- which(grepl("\\[Home\\]", original_sidebar))
-    original_sidebar[home_line] <- paste0(
-      original_sidebar[home_line],
-      "\n* [Articles]()",
-      paste("\n  * [", vignettes_titles$title, "](", vignettes_titles$link, ")",
-            collapse = "", sep = "")
-    )
-
-    writeLines(original_sidebar, fs::path_abs("docs/_sidebar.md", start = path))
-
-  } else if (doctype == "mkdocs") {
-
-    vignettes_titles$link <- gsub("/articles", "articles", vignettes_titles$link)
-
-    original_yaml <- suppressWarnings(
-      yaml::read_yaml(fs::path_abs("docs/mkdocs.yml", start = path))
-    )
-
-    # If articles are in the navbar, remove them, so that there is no duplicates
-    nav_sections <- unlist(lapply(original_yaml$nav, names))
-    # I will put reference in a section at the end
-    if ("Articles" %in% nav_sections) {
-      original_yaml$nav[[which(nav_sections == "Articles")]] <- NULL
-    }
-    if ("articles" %in% nav_sections) {
-      original_yaml$nav[[which(nav_sections == "articles")]] <- NULL
-    }
-
-    # yaml::as.yaml doesn't format plugins well when there is only one plugin
-    if (length(original_yaml$plugins) == 1) {
-      original_yaml$plugins <- list(original_yaml$plugins)
-    }
-
-    # Create section "Articles" and add vignettes in it
-    list_articles <- list("Articles" = NULL)
-    for (i in 1:nrow(vignettes_titles)) {
-      x <- list(vignettes_titles[i, 2])
-      names(x) <- paste0(vignettes_titles[i, 1])
-      list_articles[["Articles"]] <- append(
-        list_articles[["Articles"]], x, length(list_articles[["Articles"]])
-      )
-    }
-
-    new_nav <- append(original_yaml$nav, list(list_articles), 1)
-    original_yaml$nav <- new_nav
-    new_yaml <- yaml::as.yaml(original_yaml)
-
-    # yaml::as.yaml is quite inconsistent with indents and dash, especially with
-    # plugins, so I fix indents and dashes only for things after plugin (i.e
-    # plugins and nav)
-    # TODO: find a more robust solution
-    before_plugin <- gsub("plugins:.*", "", new_yaml)
-    after_plugin <- gsub(".*?(plugins:)", "\\1", new_yaml)
-    after_plugin <- gsub("- ", "  - ", after_plugin)
-    after_plugin <- gsub("    ", "    - ", after_plugin)
-    after_plugin <- gsub("- -", "-", after_plugin)
-
-    # Put reference and changelog in a section if it isn't already
-    if (length(gregexpr("Reference:", after_plugin)[[1]]) == 1) {
-      after_plugin <- gsub("Reference:", "Reference:\n    - Reference:", after_plugin)
-    }
-    if (length(gregexpr("Changelog:", after_plugin)[[1]]) == 1) {
-      after_plugin <- gsub("Changelog:", "Changelog:\n    - Changelog:", after_plugin)
-    }
-    new_yaml <- paste(before_plugin, after_plugin, sep = "")
-
-    writeLines(new_yaml, fs::path_abs("docs/mkdocs.yml", start = path))
-  }
+  file_to_update <- switch(
+    doctype,
+    "docute" = fs::path_abs("docs/index.html", start = path),
+    "docsify" = fs::path_abs("docs/_sidebar.md", start = path),
+    "mkdocs" = fs::path_abs("docs/mkdocs.yaml", start = path)
+  )
+  cli::cli_alert_warning(
+    cli::style_bold("Don't forget to check that vignettes are correctly included in {.file {file_to_update}}.")
+  )
 }
 
 
@@ -340,7 +243,7 @@
 # Check whether vignettes call child documents
 .manage_child_vignettes <- function(file, path = path) {
 
-  x  <- tinkr::yarn$new(file)
+  x <- tinkr::yarn$new(file)
 
   children <- x$body
   children <- xml2::xml_find_all(children, xpath = ".//md:code_block", x$ns)

--- a/docs/NEWS.md
+++ b/docs/NEWS.md
@@ -1,9 +1,23 @@
 ## altdoc 0.1.0.9000 (development)
 
+#### Breaking changes
+
+- Vignettes are no longer automatically added to the file that defines the structure
+  of the website. Developers must now manually update this structure and the order
+  of their articles.
+
+#### Major changes
+
 - `update_docs()` now updates the package version as well as altdoc version in
   the footer.
+
 - The NEWS or Changelog file included in the docs now automatically links issues,
   pull requests and users (only works for projects on Github).
+
+- Vignettes are now always rendered by `use_*()` or `update_docs()`. Previously,
+  they were only rendered if their content changed. This was problematic because
+  the code in a vignette can have different output while the vignette in itself
+  doesn't change.
 
 ## altdoc 0.1.0
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -63,7 +63,7 @@
 					  link: '/LICENSE'
 					}
 				],
-footer: "<a href='https://github.com/etiennebacher/altdoc'> <code> altdoc </code> v. 0.1.0.9000 </a> | Documentation made with <a href='https://github.com/etiennebacher/altdoc'> <code> altdoc </code> v. 0.1.0.1</a>"
+footer: "<a href='https://github.com/etiennebacher/altdoc'> <code> altdoc </code> v. 0.1.0.9000 </a> | Documentation made with <a href='https://github.com/etiennebacher/altdoc'> <code> altdoc </code> v. 0.1.0.9000</a>"
       })
     </script>
   </body>


### PR DESCRIPTION
1. Do not try to automatically include vignettes in the website structure: 1) this was done in a very clumsy way and 2) most of the time it is better to let authors order the vignettes as they want
2. Always render vignettes, even if their content wasn't modified. A vignette may not change but still functions used inside can produce a different output. It is much safer to always render vignettes (also allows authors to catch errors)