### PR TITLE
Use `processx`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,7 @@ Imports:
     fs,
     here,
     htmltools,
+    processx,
     rmarkdown,
     rstudioapi,
     servr,

--- a/R/preview.R
+++ b/R/preview.R
@@ -36,6 +36,13 @@ preview <- function(path = ".") {
           system2("cd", ".. && mkdocs build -q")
         }
       )
+    } else if (doctype == "quarto") {
+      cli::cli_alert_info("Rendering the website...")
+      x <- processx::run("quarto", c("render", "docs"), echo = FALSE, spinner = TRUE)
+      cli::cli_alert_info("Previewing the website...")
+      invisible(capture.output(
+        processx::process$new("quarto", c("preview", "docs"))
+      ))
     } else {
       cli::cli_alert_danger("{.file index.html} was not found. You can run one of {.code altdoc::use_*} functions to create it.")
     }

--- a/R/use.R
+++ b/R/use.R
@@ -88,8 +88,8 @@ use_mkdocs <- function(theme = NULL,
   .check_tools("mkdocs", theme)
 
   if (.is_windows() & interactive()) {
-    shell(paste("mkdocs new", fs::path_abs("docs", start = path), "-q"))
-    shell(paste("cd", fs::path_abs("docs", start = path), "&& mkdocs build -q"))
+    shell(paste("python -m mkdocs new", fs::path_abs("docs", start = path), "-q"))
+    shell(paste("cd", fs::path_abs("docs", start = path), "&& python -m mkdocs build -q"))
   } else {
     system2("mkdocs", paste("new", fs::path_abs("docs", start = path), "-q"))
     system2("cd", paste(fs::path_abs("docs", start = path), "&& mkdocs build -q"))

--- a/R/utils.R
+++ b/R/utils.R
@@ -21,7 +21,14 @@
 
 # Is mkdocs installed?
 .is_mkdocs <- function() {
-  x <- try(system2("mkdocs", stdout = TRUE, stderr = TRUE), silent = TRUE)
+  # windows...
+  # https://github.com/mkdocs/mkdocs/issues/1038
+  if (.is_windows()) {
+    x <- try(system2("python", args = c("-m", "mkdocs", "--version"),
+                     stdout = TRUE, stderr = TRUE), silent = TRUE)
+  } else {
+    x <- try(system2("mkdocs", stdout = TRUE, stderr = TRUE), silent = TRUE)
+  }
   return(!inherits(x, "try-error"))
 }
 


### PR DESCRIPTION
Close #41 

Using `processx` in the background allows us to take advantage of live reloading provided by quarto and mkdocs without blocking the R console.

TODO: implement it for mkdocs