### PR TITLE
use_*() get a preview argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: altdoc
 Title: Use 'Docsify.js', 'Docute', or 'Mkdocs' to Generate a Package Documentation
-Version: 0.2.1.9001
+Version: 0.2.1.9002
 Authors@R: 
     person(given = "Etienne",
            family = "Bacher",

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * If necessary, two spaces are automatically added in nested lists n the `NEWS` 
   (or `Changelog`) file. 
+* `preview` argument in `use_*()` allows users to suppress the web preview by
+  supplying an explicit argument or a global option.
 
 # altdoc 0.2.1
 

--- a/R/build.R
+++ b/R/build.R
@@ -114,7 +114,7 @@
 
 # Last things to do in initialization -------------------
 
-.final_steps <- function(x, path = ".") {
+.final_steps <- function(x, path = ".", preview = TRUE) {
 
   if (x == "docute") {
     .final_steps_docute(path)
@@ -129,7 +129,7 @@
   cli::cli_alert_success("{tools::toTitleCase(x)} initialized.")
   cli::cli_alert_success("Folder {.file docs} put in {.file .Rbuildignore}.")
 
-  if (interactive()) {
+  if (interactive() && isTRUE(preview)) {
     cli::cli_par()
     cli::cli_end()
     cli::cli_alert("Running preview...")

--- a/R/preview.R
+++ b/R/preview.R
@@ -15,12 +15,6 @@
 
 preview <- function(path = ".") {
 
-  # some environemnts do not handle preview well, which causes issues with
-  # testing interactively, so we introduce a global option to turn it off if
-  # needed
-  flag <- getOption("altdoc_preview", default = TRUE)
-  if (!isTRUE(flag)) return(invisible())
-
   doctype <- .doc_type(path)
 
   if (rstudioapi::isAvailable()) {

--- a/R/use.R
+++ b/R/use.R
@@ -7,6 +7,7 @@
 #' @param custom_reference Path to the file that will be sourced to generate the
 #' "Reference" section.
 #' @param quarto Logical. Whether to use quarto to render Rd documentation files
+#' @param preview Logical. Whether a preview of the documentation should be displayed in a browser window.
 #' (Reference).
 #'
 #' @export
@@ -38,7 +39,8 @@
 #' }
 
 use_docute <- function(path = ".", overwrite = FALSE,
-                       custom_reference = NULL, quarto = TRUE) {
+                       custom_reference = NULL, quarto = TRUE,
+                       preview = getOption("altdoc_preview", default = TRUE)) {
 
   path <- .convert_path(path)
   .check_is_package(path)
@@ -48,7 +50,7 @@ use_docute <- function(path = ".", overwrite = FALSE,
   .build_docs(path, custom_reference, quarto = quarto)
   .build_vignettes(path)
 
-  .final_steps(x = "docute", path)
+  .final_steps(x = "docute", path, preview = preview)
 }
 
 #' @export
@@ -56,7 +58,8 @@ use_docute <- function(path = ".", overwrite = FALSE,
 #' @rdname init
 
 use_docsify <- function(path = ".", overwrite = FALSE,
-                        custom_reference = NULL, quarto = TRUE) {
+                        custom_reference = NULL, quarto = TRUE,
+                        preview = getOption("altdoc_preview", default = TRUE)) {
 
   path <- .convert_path(path)
   .check_is_package(path)
@@ -73,7 +76,7 @@ use_docsify <- function(path = ".", overwrite = FALSE,
 
   .build_vignettes(path)
 
-  .final_steps(x = "docsify", path = path)
+  .final_steps(x = "docsify", path = path, preview = preview)
 
 }
 
@@ -93,7 +96,8 @@ use_mkdocs <- function(theme = NULL,
                        path = ".",
                        overwrite = FALSE,
                        custom_reference = NULL,
-                       quarto = TRUE) {
+                       quarto = TRUE,
+                       preview = getOption("altdoc_preview", default = TRUE)) {
 
   path <- .convert_path(path)
   .check_is_package(path)
@@ -180,5 +184,5 @@ nav:
 
   .build_vignettes(path)
 
-  .final_steps(x = "mkdocs", path = path)
+  .final_steps(x = "mkdocs", path = path, preview = preview)
 }

--- a/man/init.Rd
+++ b/man/init.Rd
@@ -10,14 +10,16 @@ use_docute(
   path = ".",
   overwrite = FALSE,
   custom_reference = NULL,
-  quarto = TRUE
+  quarto = TRUE,
+  preview = getOption("altdoc_preview", default = TRUE)
 )
 
 use_docsify(
   path = ".",
   overwrite = FALSE,
   custom_reference = NULL,
-  quarto = TRUE
+  quarto = TRUE,
+  preview = getOption("altdoc_preview", default = TRUE)
 )
 
 use_mkdocs(
@@ -25,7 +27,8 @@ use_mkdocs(
   path = ".",
   overwrite = FALSE,
   custom_reference = NULL,
-  quarto = TRUE
+  quarto = TRUE,
+  preview = getOption("altdoc_preview", default = TRUE)
 )
 }
 \arguments{
@@ -38,7 +41,9 @@ overwrite. If \code{TRUE}, the folder 'docs' is automatically overwritten.}
 \item{custom_reference}{Path to the file that will be sourced to generate the
 "Reference" section.}
 
-\item{quarto}{Logical. Whether to use quarto to render Rd documentation files
+\item{quarto}{Logical. Whether to use quarto to render Rd documentation files}
+
+\item{preview}{Logical. Whether a preview of the documentation should be displayed in a browser window.
 (Reference).}
 
 \item{theme}{Name of the theme to use. Default is basic theme. See Details


### PR DESCRIPTION
The function signature calls `getOption()`, so users can either suppress the preview manually every time, or set a global option.

This is useful when testing interactively in my environment (vscode + wsl)