### PR TITLE
Bump news and description following 0.2.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: altdoc
 Title: Use 'Docsify.js', 'Docute', or 'Mkdocs' to Generate a Package Documentation
-Version: 0.2.1.9002
+Version: 0.2.2.9002
 Authors@R: 
     person(given = "Etienne",
            family = "Bacher",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,14 @@
 # altdoc (development version)
 
-* If necessary, two spaces are automatically added in nested lists n the `NEWS` 
-  (or `Changelog`) file. 
 * `preview` argument in `use_*()` allows users to suppress the web preview by
   supplying an explicit argument or a global option.
+
+# altdoc 0.2.2
+
+* If necessary, two spaces are automatically added in nested lists in the `NEWS` 
+  (or `Changelog`) file. 
+  
+* This is the last release before a large rework of this package.
 
 # altdoc 0.2.1
 


### PR DESCRIPTION
`altdoc` 0.2.2 was released using the last commit before @rempsyc's first commit (cf #58) so I bump NEWS and description