### PR TITLE
Remove `mkdocs` special case in `preview_docs()`

### DIFF
--- a/R/preview_docs.R
+++ b/R/preview_docs.R
@@ -3,20 +3,20 @@
 #' @inheritParams setup_docs
 #' @export
 #'
-#' @return No value returned. If RStudio is used, it shows a site preview in 
+#' @return No value returned. If RStudio is used, it shows a site preview in
 #' Viewer. To preview the site in a browser or in another text editor (ex: VS Code),
 #' see the vignette on the `altdoc` website.
 #' @examples
 #' if (interactive()) {
-#' 
+#'
 #'   preview_docs()
-#' 
+#'
 #' }
-#' 
+#'
 #' # This is an example to illustrate that code-generated images are properly
 #' # displayed. See the `altdoc` website for a rendered version.
 #' with(mtcars, plot(mpg, wt))
-#' 
+#'
 preview_docs <- function(path = ".") {
   # conditional dependencies
   .assert_dependency("servr", install = TRUE)
@@ -25,26 +25,8 @@ preview_docs <- function(path = ".") {
   doctype <- .doc_type(path)
 
   if (rstudioapi::isAvailable()) {
-    if (doctype %in% c("docute", "docsify")) {
+    if (doctype %in% c("docute", "docsify", "mkdocs")) {
       servr::httw(fs::path_abs("docs/"))
-    } else if (doctype == "mkdocs") {
-      # first build
-      if (.is_windows()) {
-        shell(paste("cd", fs::path_abs("docs", start = path), " && python3 -m mkdocs build -q"))
-      } else {
-        system2("cd", paste(fs::path_abs("docs", start = path), " && python3 -m mkdocs build -q"))
-      }
-      # stop it directly to avoid opening the browser
-      servr::daemon_stop()
-
-      # getwd has to be used outside of httw, not working otherwise
-      servr::httw(
-        fs::path_abs("docs/site", start = path),
-        watch = fs::path_abs("docs/", start = path),
-        handler = function(files) {
-          system2("cd", ".. && python3 -m mkdocs build -q")
-        }
-      )
     } else {
       cli::cli_alert_danger("{.file index.html} was not found. You can run one of {.code altdoc::use_*} functions to create it.")
     }


### PR DESCRIPTION
Close #116 

`mkdocs` was a special case for previewing before it required building the `site` folder. This is no longer the case as the `site` folder is created in `render_docs()` and then moved to `docs`, meaning that we can simply use `servr::httw("docs")`.