### PR TITLE
render README.qmd/Rmd automatically

### DIFF
--- a/R/import.R
+++ b/R/import.R
@@ -1,6 +1,16 @@
 # Import files: README, license, news, CoC ------------------
 
 .import_readme <- function(src_dir, tar_dir, tool) {
+
+  # render .Rmd or .qmd file if available
+  fn_qmd <- fs::path_join(c(src_dir, "README.qmd"))
+  fn_rmd <- fs::path_join(c(src_dir, "README.Rmd"))
+  if (fs::file_exists(fn_qmd)) {
+    .qmd2md(fn_qmd, src_dir)
+  } else if (fs::file_exists(fn_rmd)) {
+    .qmd2md(fn_rmd, src_dir)
+  }
+
   src_file <- fs::path_join(c(src_dir, "README.md"))
   if (tool == "quarto_website") {
     tar_file <- fs::path_join(c(tar_dir, "index.md"))

--- a/R/utils-rmd.R
+++ b/R/utils-rmd.R
@@ -5,15 +5,16 @@
   if (is.null(img_paths)) {
     return(invisible())
   }
-
   good_path <- .doc_path(path)
-  fs::dir_create(paste0(good_path, "/README_assets"))
-  for (i in seq_along(img_paths)) {
-    fs::file_copy(
-      img_paths[i],
-      paste0(good_path, "/README_assets/", trimws(basename(img_paths[i]))),
-      overwrite = TRUE
-    )
+  for (assets in c("/README_assets", "/README.markdown_strict_files")) {
+    fs::dir_create(paste0(good_path, assets))
+    for (i in seq_along(img_paths)) {
+      fs::file_copy(
+        img_paths[i],
+        fs::path_join(c(good_path, assets, trimws(basename(img_paths[i])))),
+        overwrite = TRUE
+      )
+    }
   }
 }
 


### PR DESCRIPTION
When there is a `README.qmd` or a `README.Rmd` in the root directory, that file is rendered automatically to `README.md` at the very start of the process.

Then, `README.md` is copied over as we were doing before.

Since we now render all files with Quarto, the assets are stored in `README.markdown_strict_files/` rather than `README_assets/`. I have kept both just in case we roll back to `rmarkdown::render` at some point.

