### PR TITLE
Change GHA to `pkgdown`-like GHA

### DIFF
--- a/.github/workflows/altdoc.yaml
+++ b/.github/workflows/altdoc.yaml
@@ -11,55 +11,34 @@ on:
 
 name: altdoc
 
-concurrency:
-  group: altdoc-${{ github.event_name != 'pull_request' || github.run_id }}
-  cancel-in-progress: true
-
-env:
-  USE_BSPM: "true"
-  _R_CHECK_FORCE_SUGGESTS_: "false"
-  R_GH: true
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-permissions:
-  contents: write
-
 jobs:
   altdoc:
     runs-on: ubuntu-latest
-    container:
-      image: rocker/r2u:latest
+    # Only restrict concurrency for non-PR jobs
+    concurrency:
+      group: altdoc-${{ github.event_name != 'pull_request' || github.run_id }}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 
-      # The quarto-actions/setup doesn't work in containers so need to install manually
-      # https://github.com/quarto-dev/quarto-actions/issues/12
-      - name: Manually install Quarto
-        run: |
-          wget https://github.com/quarto-dev/quarto-cli/releases/download/v1.3.450/quarto-1.3.450-linux-amd64.deb
-          apt install ./quarto-1.3.450-linux-amd64.deb
+      - uses: quarto-dev/quarto-actions/setup@v2
 
-      - name: Package Dependencies
-        run: R -q -e 'remotes::install_deps(".", dependencies=TRUE)'
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
 
-      - name: Build Package
-        run: R CMD build --no-build-vignettes --no-manual .
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::altdoc, local::.
+          needs: website
 
       - name: Build site
         run: |
-          utils::install.packages(".", repos = NULL, type = "source")
           altdoc::render_docs(parallel = TRUE, freeze = FALSE)
         shell: Rscript {0}
-
-      # install required dependency for github-pages-deploy action
-      - name: Install rsync 📚
-        run: |
-          apt-get update && apt-get install -y rsync git
-          git --version
-          ls
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git init
-          git remote add origin https://github.com/etiennebacher/altdoc
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'

--- a/.github/workflows/altdoc.yaml
+++ b/.github/workflows/altdoc.yaml
@@ -33,7 +33,6 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::altdoc, local::.
-          needs: website
 
       - name: Build site
         run: |

--- a/inst/misc/altdoc.yaml
+++ b/inst/misc/altdoc.yaml
@@ -21,22 +21,28 @@ env:
   R_GH: true
   GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
-jobs:
-  altdoc:
+
+altdoc:
+    runs-on: ubuntu-latest
+    # Only restrict concurrency for non-PR jobs
+    concurrency:
+      group: altdoc-${{ github.event_name != 'pull_request' || github.run_id }}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     permissions:
       contents: write
-    runs-on: ubuntu-latest
-    container:
-      image: rocker/r2u:latest
     steps:
       - uses: actions/checkout@v4
 
-      # The quarto-actions/setup doesn't work in containers so need to install manually
-      # https://github.com/quarto-dev/quarto-actions/issues/12
-      - name: Manually install Quarto
-        run: |
-          wget https://github.com/quarto-dev/quarto-cli/releases/download/v1.3.450/quarto-1.3.450-linux-amd64.deb
-          apt install ./quarto-1.3.450-linux-amd64.deb
+      - uses: quarto-dev/quarto-actions/setup@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::altdoc, local::.
 
       $ALTDOC_MKDOCS_START
       - name: Set up Python
@@ -56,15 +62,8 @@ jobs:
       #     python3 -m pip install mkdocs-material   # install material theme
       $ALTDOC_MKDOCS_END
 
-      - name: Package Dependencies
-        run: R -q -e 'remotes::install_deps(".", dependencies=TRUE)'
-
-      - name: Build Package
-        run: R CMD build --no-build-vignettes --no-manual .
-
       - name: Build site
         run: |
-          utils::install.packages(".", repos = NULL, type = "source")
           altdoc::render_docs(parallel = TRUE, freeze = FALSE)
         shell: Rscript {0}
 


### PR DESCRIPTION
I can't figure out how to make the "Deploy to GitHub pages" step work with the `r2u` container. I think this is due to the fact it is a container so we need to install and reconfigure git inside the container, but I've tried several things and nothing worked.

So here I'm just adapting the `pkgdown` workflow for our needs. It's no big deal to have a setup 30sec slower, most of the time will be spent on rendering the website for packages with more vignettes/man pages