### PR TITLE
Use package name, not root directory name

### DIFF
--- a/R/rd2qmd.R
+++ b/R/rd2qmd.R
@@ -25,7 +25,7 @@
   idx <- grepl("<.code", tmp)
 
   # examples: evaluate code blocks (assume examples are always last)
-  pkg <- basename(getwd())
+  pkg <- .pkg_name(".")
   pkg_load <- paste0("library(", pkg, ")")
   idx <- which(tmp == "<h3>Examples</h3>")
   if (length(idx) == 1) {


### PR DESCRIPTION
Directory name is "r-polars", but we want to load "polars"