### PR TITLE
Misc fixes for mkdocs

### DIFF
--- a/R/preview_docs.R
+++ b/R/preview_docs.R
@@ -25,26 +25,8 @@ preview_docs <- function(path = ".") {
   tool <- .doc_type(path)
 
   if (rstudioapi::isAvailable()) {
-    if (tool %in% c("docute", "docsify")) {
+    if (tool %in% c("docute", "docsify", "mkdocs")) {
       servr::httw(fs::path_abs("docs/"))
-    } else if (tool == "mkdocs") {
-      # first build
-      if (.is_windows()) {
-        shell(paste("cd", fs::path_abs("docs", start = path), " && python3 -m mkdocs build -q"))
-      } else {
-        system2("cd", paste(fs::path_abs("docs", start = path), " && python3 -m mkdocs build -q"))
-      }
-      # stop it directly to avoid opening the browser
-      servr::daemon_stop()
-
-      # getwd has to be used outside of httw, not working otherwise
-      servr::httw(
-        fs::path_abs("docs/site", start = path),
-        watch = fs::path_abs("docs/", start = path),
-        handler = function(files) {
-          system2("cd", ".. && python3 -m mkdocs build -q")
-        }
-      )
     } else {
       cli::cli_alert_danger("{.file index.html} was not found. You can run one of {.code altdoc::use_*} functions to create it.")
     }

--- a/R/settings_mkdocs.R
+++ b/R/settings_mkdocs.R
@@ -43,12 +43,15 @@
     fn <- fs::path_join(c(path, "mkdocs.yml"))
     writeLines(settings, fn)
 
-    # plugins must be a list otherwise this command breaks: mkdocs build -q
+    # These two elements should be lists in the yaml format, not single elements,
+    # otherwise mkdocs breaks
     yml <- yaml::read_yaml(fn)
-    if ("plugins" %in% names(yml)) {
-        yml[["plugins"]] <- as.list(yml[["plugins"]])
+    for (i in c("extra_css", "plugins")) {
+        if (!is.null(yml[[i]]) && !is.list(length(yml[[i]]))) {
+            yml[[i]] = as.list(yml[[i]])
+        }
     }
-    yaml::write_yaml(yml, fn)
+    yaml::write_yaml(yml, fn, indent.mapping.sequence = TRUE)
 
     # render mkdocs
     if (.is_windows()) {
@@ -103,7 +106,7 @@
             }
         }
         tmp <- tempfile()
-        yaml::write_yaml(yml, file = tmp)
+        yaml::write_yaml(yml, file = tmp, indent.mapping.sequence = TRUE)
         sidebar <- .readlines(tmp)
     } else {
         sidebar <- sidebar[!grepl("\\$ALTDOC_VIGNETTE_BLOCK", sidebar)]
@@ -134,7 +137,7 @@
             }
         }
         tmp <- tempfile()
-        yaml::write_yaml(yml, file = tmp)
+        yaml::write_yaml(yml, file = tmp, indent.mapping.sequence = TRUE)
         sidebar <- .readlines(tmp)
     } else {
         sidebar <- sidebar[!grepl("\\$ALTDOC_MAN_BLOCK", sidebar)]

--- a/R/settings_quarto_website.R
+++ b/R/settings_quarto_website.R
@@ -7,7 +7,7 @@
     settings <- settings[!grepl("^\\w*$", settings)]
 
     fn <- fs::path_join(c(path, "_quarto", "_quarto.yml"))
-    yaml::write_yaml(settings, fn)
+    yaml::write_yaml(settings, fn, indent.mapping.sequence = TRUE)
 
     # yaml::write_yaml converts true to yes, but quarto complains
     settings <- .readlines(fn)


### PR DESCRIPTION
Not sure when the `preview` part came back, I had removed it in a previous PR.

Always write the yaml with indentation, otherwise it breaks mkdocs