### PR TITLE
Fix `.parse_news()` when two names have the same root

### DIFF
--- a/R/import_misc.R
+++ b/R/import_misc.R
@@ -117,6 +117,7 @@
   )
   people <- gsub("^ ", "", people)
   people <- gsub("^\\(", "", people)
+  people <- unique(people)
 
   if (length(people) > 0) {
     people_link <- paste0("https://github.com/", gsub("@", "", people))
@@ -132,8 +133,8 @@
 
     for (i in seq_len(nrow(people_out))) {
       new_news <- gsub(
-        people_out[i, "in_text"],
-        people_out[i, "replacement"],
+        paste0("[^[]", people_out[i, "in_text"]),
+        paste0(" ", people_out[i, "replacement"]),
         new_news
       )
     }


### PR DESCRIPTION
Close #185

Problem was that there are both `@vincent` and `@vincentarelbundock` in the NEWS file. Replacing the latter works fine, but then the replacement of the former messes up the first replacement. 