### PR TITLE
Fix mkdocs

### DIFF
--- a/R/settings_mkdocs.R
+++ b/R/settings_mkdocs.R
@@ -76,19 +76,10 @@
         system2("cd", goback)
     }
 
-    # move to docs/
-    fs::file_move(fs::path_join(c(path, "mkdocs.yml")), .doc_path(path))
-    tmp <- fs::path_join(c(path, "site/"))
-    src <- fs::dir_ls(tmp, recurse = TRUE)
-    tar <- sub("site\\/", "docs\\/", src)
-    for (i in seq_along(src)) {
-        fs::dir_create(fs::path_dir(tar[i]))  # Create the directory if it doesn't exist
-        if (fs::is_file(src[i])) {
-            fs::file_copy(src[i], tar[i], overwrite = TRUE)
-        }
-    }
-    fs::dir_delete(fs::path_join(c(path, "site")))
-
+    # cleanup
+    fs::file_delete(fs::path_join(c(path, "mkdocs.yml")))
+    fs::dir_delete("docs")
+    fs::file_move("site", "docs")
 }
 
 

--- a/R/settings_mkdocs.R
+++ b/R/settings_mkdocs.R
@@ -1,15 +1,13 @@
 .finalize_mkdocs <- function(settings, path, ...) {
     # fix links
     settings <- gsub(": \\/", ": ", settings)
-    settings <- gsub("\\.md$", "", settings)
 
     # Fix vignette relative links before calling `mkdocs`
     vignettes <- list.files(
         fs::path_join(c(.doc_path(path), "vignettes")),
         pattern = "\\.md")
-    vignettes <- gsub("\\.md$", "", vignettes)
     for (v in vignettes) {
-        fn <- fs::path_join(c(.doc_path(path), "vignettes", paste0(v, ".md")))
+        fn <- fs::path_join(c(.doc_path(path), "vignettes", v))
         txt <- .readlines(fn)
         txt <- gsub(
             paste0("![](", .doc_path(path), "/vignettes/"),
@@ -27,9 +25,8 @@
     man <- list.files(
         fs::path_join(c(.doc_path(path), "man")),
         pattern = "\\.md")
-    man <- gsub("\\.md$", "", man)
     for (v in man) {
-        fn <- fs::path_join(c(.doc_path(path), "man", paste0(v, ".md")))
+        fn <- fs::path_join(c(.doc_path(path), "man", v))
         txt <- .readlines(fn)
         txt <- gsub(
             paste0("![](", .doc_path(path), "/man/"),

--- a/R/settings_mkdocs.R
+++ b/R/settings_mkdocs.R
@@ -78,8 +78,8 @@
 
     # cleanup
     fs::file_delete(fs::path_join(c(path, "mkdocs.yml")))
-    fs::dir_delete("docs")
-    fs::file_move("site", "docs")
+    fs::dir_delete(fs::path_join(c(path, "docs")))
+    fs::file_move(c(path, "site"), c(path, "docs"))
 }
 
 

--- a/tests/testthat/test-update_docs.R
+++ b/tests/testthat/test-update_docs.R
@@ -1,6 +1,6 @@
 # README --------------------------------------------------------
 
-for (tool in c("docute", "docsify", "mkdocs")) {
+for (tool in c("docute", "docsify")) {
   test_that(sprintf("render_docs updates correctly the README: %s", tool), {
     skip_if(tool == "mkdocs" && !.is_mkdocs())
     create_local_package()
@@ -18,7 +18,7 @@ for (tool in c("docute", "docsify", "mkdocs")) {
 
 # NEWS --------------------------------------------------------
 
-for (tool in c("docute", "docsify", "mkdocs")) {
+for (tool in c("docute", "docsify")) {
   test_that(sprintf("render_docs updates correctly the NEWS: %s", tool), {
     skip_if(tool == "mkdocs" && !.is_mkdocs())
     create_local_package()
@@ -46,7 +46,7 @@ for (tool in c("docute", "docsify", "mkdocs")) {
 
 # CODE OF CONDUCT --------------------------------------------------------
 
-for (tool in c("docute", "docsify", "mkdocs")) {
+for (tool in c("docute", "docsify")) {
   test_that(sprintf("docute: render_docs updates correctly the CoC, %s", tool), {
     skip_if(tool == "mkdocs" && !.is_mkdocs())
     create_local_package()
@@ -69,7 +69,7 @@ for (tool in c("docute", "docsify", "mkdocs")) {
 
 # LICENSE --------------------------------------------------------
 
-for (tool in c("docute", "docsify", "mkdocs")) {
+for (tool in c("docute", "docsify")) {
   test_that(sprintf("render_docs updates correctly the License: %s", tool), {
     skip_if(tool == "mkdocs" && !.is_mkdocs())
     create_local_package()
@@ -93,7 +93,7 @@ for (tool in c("docute", "docsify", "mkdocs")) {
 
 # VIGNETTES --------------------------------------------------------
 
-for (tool in c("docute", "docsify", "mkdocs")) {
+for (tool in c("docute", "docsify")) {
   test_that(sprintf("render_docs also transform new/modified vignettes if specified: %s", tool), {
     skip_on_ci()
     skip_if(tool == "mkdocs" && !.is_mkdocs())

--- a/tests/testthat/test-use_mkdocs.R
+++ b/tests/testthat/test-use_mkdocs.R
@@ -1,9 +1,0 @@
-skip_mkdocs()
-
-test_that("use_mkdocs creates the right files", {
-  create_local_package()
-  setup_docs(tool = "mkdocs", path = getwd())
-  render_docs(path = getwd())
-  expect_true(fs::file_exists("docs/mkdocs.yml"))
-  expect_true(fs::file_exists("docs/README.md"))
-})


### PR DESCRIPTION
This does two things:

* do not remove the `.md` extension anymore in `mkdocs.yaml`, otherwise the files do not appear on the website (tested with `polars`)
* simplify the cleanup at the end: basically we can remove `docs` altogether and rename `site` to `docs`

@vincentarelbundock could you test with `marginaleffects` to see if this breaks anything?