### PR TITLE
Find the best python installation

### DIFF
--- a/R/settings_mkdocs.R
+++ b/R/settings_mkdocs.R
@@ -66,12 +66,12 @@
         ### TODO: (cd <path> && python3 -m mkdocs build -q) should automatically go back to the previous directory
         ### https://stackoverflow.com/questions/10382141/temporarily-change-current-working-directory-in-bash-to-run-a-command
         goback <- fs::path_abs(getwd())
-        cmd <- paste("cd", fs::path_abs(path), "&& python3 -m mkdocs build -q")
+        cmd <- paste("cd", fs::path_abs(path), "&&", .python_installation(), "-m mkdocs build -q")
         shell(cmd)
         shell(paste("cd", goback))
     } else {
         goback <- getwd()
-        cmd <- paste(fs::path_abs(path), "&& python3 -m mkdocs build -q")
+        cmd <- paste(fs::path_abs(path), "&&", .python_installation(), "-m mkdocs build -q")
         system2("cd", cmd)
         system2("cd", goback)
     }

--- a/R/utils.R
+++ b/R/utils.R
@@ -14,6 +14,12 @@
   .Platform$OS.type == "windows"
 }
 
+# this will give priority to the .venv folder if there is one in the package
+# root directory, and it will pick the more general installation otherwise
+.python_installation <- function() {
+  Sys.which("python")
+}
+
 # Is pip3 installed?
 .is_pip3 <- function() {
   x <- try(system2("pip3", args = "--version", stdout = TRUE, stderr = TRUE), silent = TRUE)
@@ -22,7 +28,7 @@
 
 # Is mkdocs installed?
 .is_mkdocs <- function() {
-  x <- try(system2("python3", args = "-m mkdocs", stdout = TRUE, stderr = TRUE), silent = TRUE)
+  x <- try(system2(.python_installation(), args = "-m mkdocs", stdout = TRUE, stderr = TRUE), silent = TRUE)
   return(!inherits(x, "try-error"))
 }
 
@@ -31,7 +37,6 @@
   x <- try(system2("sphinx-build", args = "--version", stdout = TRUE, stderr = TRUE), silent = TRUE)
   return(!inherits(x, "try-error"))
 }
-
 
 # https://stackoverflow.com/a/42945293/11598948
 .stop_quietly <- function() {


### PR DESCRIPTION
In the polars workflow, we set up a `.venv` folder where `mkdocs` is installed. The aim of this PR is to prioritize the `.venv` folder over the more general python installation