### PR TITLE
Improve test coverage

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -35,6 +35,8 @@ jobs:
           use-public-rspm: true
       - uses: r-lib/actions/setup-pandoc@v2
 
+      - uses: quarto-dev/quarto-actions/setup@v2
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -23,6 +23,8 @@ jobs:
           python-version: 3.11
           architecture: x64
 
+      - uses: quarto-dev/quarto-actions/setup@v2
+
       - name: Install Mkdocs
         run: |
           python3 -m pip install --upgrade pip     # install pip

--- a/R/check.R
+++ b/R/check.R
@@ -2,13 +2,12 @@
 
 .check_is_package <- function(path) {
   if (!.dir_is_package(path)) {
-    cli::cli_alert_danger("{.code altdoc} only works in packages.")
-    .stop_quietly()
+    cli::cli_abort("{.code altdoc} only works in packages.")
   }
 }
 
 
-# 
+#
 # Check that mkdocs/sphinx are installed -------------------------
 
 .check_tools <- function(tool) {

--- a/R/preview_docs.R
+++ b/R/preview_docs.R
@@ -23,18 +23,15 @@ preview_docs <- function(path = ".") {
   .assert_dependency("rstudioapi", install = TRUE)
 
   tool <- .doc_type(path)
+  if (.folder_is_empty(fs::path_join(c(path, "docs")))) {
+    cli::cli_abort("You must render the docs before previewing them. Use {.code altdoc::render_docs()}.")
+  }
 
   if (rstudioapi::isAvailable()) {
-    if (tool %in% c("docute", "docsify", "mkdocs")) {
-      servr::httw(fs::path_abs("docs/"))
-    } else {
-      cli::cli_alert_danger("{.file index.html} was not found. You can run one of {.code altdoc::use_*} functions to create it.")
-    }
+    servr::httw(fs::path_abs("docs/"))
   } else {
     if (fs::file_exists(fs::path_abs("docs/index.html", start = path))) {
       utils::browseURL(fs::path_abs("docs/index.html", start = path))
-    } else if (fs::file_exists(fs::path_abs("docs/site/index.html", start = path))) {
-      utils::browseURL(fs::path_abs("docs/site/index.html", start = path))
     }
   }
 }

--- a/R/setup_docs.R
+++ b/R/setup_docs.R
@@ -72,18 +72,24 @@ setup_docs <- function(tool, path = ".", overwrite = FALSE) {
   if (!fs::dir_exists(altdoc_dir)) {
     cli::cli_alert_info("Creating `altdoc/` directory.")
     fs::dir_create(altdoc_dir)
-  } else if (isTRUE(overwrite)) {
-    # start from zero when the setup is overwritten
-    fs::dir_delete(docs_dir)
+  } else {
+    if (isTRUE(overwrite)) {
+      # start from zero when the setup is overwritten
+      fs::dir_delete(docs_dir)
 
-    file_names <- c(
-      "mkdocs.yml", "quarto_website.yml", "docute.html", "docsify.html", "docsify.md", ".nojekyll", "freeze.rds"
-    )
-    for (file_name in file_names) {
-      file_name <- fs::path_join(c(altdoc_dir, file_name))
-      if (fs::file_exists(file_name)) {
-        fs::file_delete(file_name)
+      file_names <- c(
+        "mkdocs.yml", "quarto_website.yml", "docute.html", "docsify.html", "docsify.md", ".nojekyll", "freeze.rds"
+      )
+      for (file_name in file_names) {
+        file_name <- fs::path_join(c(altdoc_dir, file_name))
+        if (fs::file_exists(file_name)) {
+          fs::file_delete(file_name)
+        }
       }
+    } else {
+      cli::cli_abort(
+        "{.file {altdoc_dir}} already exists. Delete it or set `overwrite=TRUE`."
+      )
     }
   }
 

--- a/tests/testthat/examples/examples-qmd/with-preamble.qmd
+++ b/tests/testthat/examples/examples-qmd/with-preamble.qmd
@@ -1,0 +1,13 @@
+---
+date: 2054-12-12
+---
+
+# first section
+
+hello there, this document *does have* a preamble
+
+# path
+
+here's a path to a badge: [![R-universe status
+badge](https://grantmcdermott.r-universe.dev/badges/plot2)](https://grantmcdermott.r-universe.dev)
+

--- a/tests/testthat/examples/examples-qmd/without-preamble.qmd
+++ b/tests/testthat/examples/examples-qmd/without-preamble.qmd
@@ -1,0 +1,8 @@
+# first section
+
+hello there, this document doesn't have a preamble
+
+# path
+
+here's a path to a badge: [![R-universe status
+badge](https://grantmcdermott.r-universe.dev/badges/plot2)](https://grantmcdermott.r-universe.dev)

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -62,7 +62,7 @@ create_local_thing <- function(
     },
     envir = env
   )
-  ui_silence(
+  usethis::ui_silence(
     switch(thing,
       package = create_package(dir, rstudio = rstudio, open = FALSE, check_name = FALSE),
       project = create_project(dir, rstudio = rstudio, open = FALSE)

--- a/tests/testthat/test-freeze.R
+++ b/tests/testthat/test-freeze.R
@@ -1,0 +1,23 @@
+test_that("comparing hashes works", {
+  source_file <- tempfile()
+  fs::file_copy(test_path("examples/examples-man/between.Rd"), source_file)
+  hashes <- digest::digest(.readlines(source_file))
+  names(hashes) <- source_file
+  expect_true(.read_freeze(source_file, source_file, hashes))
+
+  other_source_file <- test_path("examples/examples-man/between.md")
+  expect_false(.read_freeze(other_source_file, other_source_file, hashes))
+
+  # modified file doesn't have the same hash
+  mod <- c(.readlines(source_file), "abc")
+  cat(mod, file = source_file)
+  expect_false(.read_freeze(source_file, source_file, hashes))
+})
+
+test_that(".read_freeze is FALSE if files don't exist", {
+  source_file <- tempfile()
+  fs::file_copy(test_path("examples/examples-man/between.Rd"), source_file)
+  hashes <- digest::digest(.readlines(source_file))
+  names(hashes) <- source_file
+  expect_false(.read_freeze("foobar", "foobar", hashes))
+})

--- a/tests/testthat/test-preview_docs.R
+++ b/tests/testthat/test-preview_docs.R
@@ -1,0 +1,13 @@
+test_that("preview_docs: basic errors", {
+  create_local_package()
+  expect_error(
+    preview_docs(),
+    "No documentation tool detected"
+  )
+
+  setup_docs("docute")
+  expect_error(
+    preview_docs(),
+    "You must render the docs before previewing them"
+  )
+})

--- a/tests/testthat/test-qmd2md.R
+++ b/tests/testthat/test-qmd2md.R
@@ -7,7 +7,17 @@ test_that("use template preamble if no preamble in file", {
   fs::file_copy(source, "vignettes")
   preamble <- .readlines("altdoc/preamble_vignettes_qmd.yml")
   vignette_qmd <- list.files("vignettes", full.names = TRUE)[1]
-  .qmd2md(vignette_qmd, fs::path_abs("vignettes"), preamble = preamble)
+
+  print(
+    quarto::quarto_render(
+      input = path.expand(tar_file),
+      output_format = "md",
+      quiet = FALSE,
+      as_job = FALSE
+    )
+  )
+
+  .qmd2md(vignette_qmd, "vignettes", preamble = preamble)
 
   vignette_md <- list.files("vignettes", full.names = TRUE, pattern = "\\.md$")[1]
   print(vignette_md)
@@ -28,7 +38,7 @@ test_that("do not use template preamble if preamble in file", {
   fs::file_copy(source, "vignettes")
   preamble <- .readlines("altdoc/preamble_vignettes_qmd.yml")
   vignette_qmd <- list.files("vignettes", full.names = TRUE)[1]
-  .qmd2md(vignette_qmd, fs::path_abs("vignettes"), preamble = preamble)
+  .qmd2md(vignette_qmd, "vignettes", preamble = preamble)
 
   vignette_md <- list.files("vignettes", full.names = TRUE, pattern = "\\.md$")[1]
 

--- a/tests/testthat/test-qmd2md.R
+++ b/tests/testthat/test-qmd2md.R
@@ -1,0 +1,36 @@
+test_that("use template preamble if no preamble in file", {
+  source <- tempfile(fileext = ".qmd")
+  fs::file_copy(test_path("examples/examples-qmd/without-preamble.qmd"), source)
+  create_local_package()
+  setup_docs("docute")
+  fs::dir_create("vignettes")
+  fs::file_copy(source, "vignettes")
+  preamble <- .readlines("altdoc/preamble_vignettes_qmd.yml")
+  vignette_qmd <- list.files("vignettes", full.names = TRUE)[1]
+  .qmd2md(vignette_qmd, "vignettes", preamble = preamble)
+
+  vignette_md <- list.files("vignettes", full.names = TRUE, pattern = "\\.md$")[1]
+
+  # we use our preamble so quarto shouldn't automatically add the ".png" extension
+  content <- .readlines(vignette_md)
+  expect_true(any(grepl("badges/plot2)", content, fixed = TRUE)))
+})
+
+test_that("do not use template preamble if preamble in file", {
+  source <- tempfile(fileext = ".qmd")
+  fs::file_copy(test_path("examples/examples-qmd/with-preamble.qmd"), source)
+  create_local_package()
+  setup_docs("docute")
+  fs::dir_create("vignettes")
+  fs::file_copy(source, "vignettes")
+  preamble <- .readlines("altdoc/preamble_vignettes_qmd.yml")
+  vignette_qmd <- list.files("vignettes", full.names = TRUE)[1]
+  .qmd2md(vignette_qmd, "vignettes", preamble = preamble)
+
+  vignette_md <- list.files("vignettes", full.names = TRUE, pattern = "\\.md$")[1]
+
+  # there's already a preamble so we don't use ours. Quarto should automatically
+  # add the ".png" extension
+  content <- .readlines(vignette_md)
+  expect_true(any(grepl("badges/plot2.png)", content, fixed = TRUE)))
+})

--- a/tests/testthat/test-qmd2md.R
+++ b/tests/testthat/test-qmd2md.R
@@ -8,6 +8,7 @@ test_that("use template preamble if no preamble in file", {
   preamble <- .readlines("altdoc/preamble_vignettes_qmd.yml")
   vignette_qmd <- list.files("vignettes", full.names = TRUE)[1]
 
+  tar_file <- fs::path_join(c("vignettes", basename(vignette_qmd)))
   print(
     quarto::quarto_render(
       input = path.expand(tar_file),

--- a/tests/testthat/test-qmd2md.R
+++ b/tests/testthat/test-qmd2md.R
@@ -7,7 +7,7 @@ test_that("use template preamble if no preamble in file", {
   fs::file_copy(source, "vignettes")
   preamble <- .readlines("altdoc/preamble_vignettes_qmd.yml")
   vignette_qmd <- list.files("vignettes", full.names = TRUE)[1]
-  .qmd2md(vignette_qmd, "vignettes", preamble = preamble)
+  .qmd2md(vignette_qmd, fs::path_abs("vignettes"), preamble = preamble)
 
   vignette_md <- list.files("vignettes", full.names = TRUE, pattern = "\\.md$")[1]
 
@@ -25,7 +25,7 @@ test_that("do not use template preamble if preamble in file", {
   fs::file_copy(source, "vignettes")
   preamble <- .readlines("altdoc/preamble_vignettes_qmd.yml")
   vignette_qmd <- list.files("vignettes", full.names = TRUE)[1]
-  .qmd2md(vignette_qmd, "vignettes", preamble = preamble)
+  .qmd2md(vignette_qmd, fs::path_abs("vignettes"), preamble = preamble)
 
   vignette_md <- list.files("vignettes", full.names = TRUE, pattern = "\\.md$")[1]
 

--- a/tests/testthat/test-qmd2md.R
+++ b/tests/testthat/test-qmd2md.R
@@ -8,22 +8,8 @@ test_that("use template preamble if no preamble in file", {
   preamble <- .readlines("altdoc/preamble_vignettes_qmd.yml")
   vignette_qmd <- list.files("vignettes", full.names = TRUE)[1]
 
-  tar_file <- fs::path_join(c("vignettes", basename(vignette_qmd)))
-  print(
-    quarto::quarto_render(
-      input = path.expand(tar_file),
-      output_format = "md",
-      quiet = FALSE,
-      as_job = FALSE
-    )
-  )
-
   .qmd2md(vignette_qmd, "vignettes", preamble = preamble)
-
   vignette_md <- list.files("vignettes", full.names = TRUE, pattern = "\\.md$")[1]
-  print(vignette_md)
-  print(fs::file_exists(vignette_md))
-  print(list.files("vignettes"))
 
   # we use our preamble so quarto shouldn't automatically add the ".png" extension
   content <- .readlines(vignette_md)

--- a/tests/testthat/test-qmd2md.R
+++ b/tests/testthat/test-qmd2md.R
@@ -10,6 +10,9 @@ test_that("use template preamble if no preamble in file", {
   .qmd2md(vignette_qmd, fs::path_abs("vignettes"), preamble = preamble)
 
   vignette_md <- list.files("vignettes", full.names = TRUE, pattern = "\\.md$")[1]
+  print(vignette_md)
+  print(fs::file_exists(vignette_md))
+  print(list.files("vignettes"))
 
   # we use our preamble so quarto shouldn't automatically add the ".png" extension
   content <- .readlines(vignette_md)

--- a/tests/testthat/test-rd2qmd.R
+++ b/tests/testthat/test-rd2qmd.R
@@ -1,0 +1,32 @@
+test_that(".rd2qmd works", {
+  rd_file <- testthat::test_path("examples/examples-man/between.Rd")
+  dest <- tempdir()
+  .rd2qmd(rd_file, dest)
+  qmd_file <- fs::path_join(c(dest, "between.qmd"))
+  expect_true(fs::file_exists(qmd_file))
+
+  content <- .readlines(qmd_file)
+  h3 <- grep("^### ", content, value = TRUE)
+  expect_equal(
+    h3,
+    c("### Description", "### Usage", "### Arguments", "### Examples")
+  )
+
+  h2 <- grep("^## ", content, value = TRUE)
+  expect_equal(h2, "## Do values in a numeric vector fall in specified range? {.unnumbered}")
+
+  # examples
+  expect_true(any(grepl("```{r, warning=FALSE", content, fixed = TRUE)))
+  expect_true(any(grepl("library(altdoc)", content, fixed = TRUE)))
+})
+
+test_that(".rd2qmd: basic errors", {
+  expect_error(
+    .rd2qmd("foo"),
+    "must be a valid file path"
+  )
+  expect_error(
+    .rd2qmd(testthat::test_path("examples/examples-man/between.Rd"), "foo"),
+    "must be a valid directory"
+  )
+})

--- a/tests/testthat/test-settings.R
+++ b/tests/testthat/test-settings.R
@@ -1,0 +1,17 @@
+test_that(".substitute_altdoc_vars removes github if no url", {
+  create_local_package()
+  desc::desc_set_urls("https://foobar.com")
+  setup_docs("docute")
+  render_docs()
+  content <- .readlines("docs/index.html")
+  expect_false(any(grepl("$ALTDOC_PACKAGE_URL_GITHUB", content, fixed = TRUE)))
+})
+
+test_that(".substitute_altdoc_vars removes website if no url", {
+  create_local_package()
+  desc::desc_set_urls("https://github.com/foo/bar")
+  setup_docs("docute")
+  render_docs()
+  content <- .readlines("docs/index.html")
+  expect_false(any(grepl("$ALTDOC_PACKAGE_URL", content, fixed = TRUE)))
+})

--- a/tests/testthat/test-setup_docs.R
+++ b/tests/testthat/test-setup_docs.R
@@ -1,4 +1,29 @@
-test_that(paste("overwrite=TRUE works:", "docute"), {
+test_that("must be a package", {
+  create_local_project()
+  expect_error(
+    setup_docs(tool = "docute", path = getwd()),
+    "only works in packages"
+  )
+})
+
+test_that("setup_docs doesn't automatically overwrite", {
+    create_local_package()
+    setup_docs(tool = "docute", path = getwd())
+    expect_error(
+      setup_docs("docsify", path = getwd()),
+      "already exists"
+    )
+})
+
+test_that("setup_docs errors if missing tool", {
+    create_local_package()
+    expect_error(
+      setup_docs(path = getwd()),
+      "argument must be \"docsify\", \"docute\""
+    )
+})
+
+test_that("overwrite=TRUE works: docute", {
     create_local_package()
     setup_docs(tool = "docute", path = getwd())
     cat("Cruft", file = "altdoc/docute.html", append = TRUE)
@@ -9,7 +34,7 @@ test_that(paste("overwrite=TRUE works:", "docute"), {
     expect_false("Cruft" %in% txt)
 })
 
-test_that(paste("overwrite=TRUE works:", "docsify"), {
+test_that("overwrite=TRUE works: docsify", {
     create_local_package()
     setup_docs(tool = "docsify", path = getwd())
     cat("Cruft", file = "altdoc/docsify.html", append = TRUE)
@@ -20,9 +45,7 @@ test_that(paste("overwrite=TRUE works:", "docsify"), {
     expect_false("Cruft" %in% txt)
 })
 
-
-
-test_that(paste("overwrite=TRUE works:", "mkdocs"), {
+test_that("overwrite=TRUE works: mkdocs", {
     skip_if_not(.is_mkdocs())
     create_local_package()
     setup_docs(tool = "mkdocs", path = getwd())

--- a/tests/testthat/test-setup_github_actions.R
+++ b/tests/testthat/test-setup_github_actions.R
@@ -1,0 +1,30 @@
+test_that(".setup_github_actions cannot overwrite", {
+  create_local_package()
+  setup_docs("docute")
+  fs::dir_create(".github/workflows")
+  fs::file_create(".github/workflows/altdoc.yaml")
+  expect_error(
+    setup_github_actions(),
+    "already exists"
+  )
+})
+
+test_that(".setup_github_actions works if not mkdocs", {
+  create_local_package()
+  setup_docs("docute")
+  setup_github_actions()
+  expect_true(fs::file_exists(".github/workflows/altdoc.yaml"))
+  content <- .readlines(".github/workflows/altdoc.yaml")
+  expect_false(any(grepl("$ALTDOC_MKDOCS_START", content, fixed = TRUE)))
+  expect_false(any(grepl("install mkdocs", content, fixed = TRUE)))
+})
+
+test_that(".setup_github_actions works if mkdocs", {
+  create_local_package()
+  setup_docs("mkdocs")
+  setup_github_actions()
+  expect_true(fs::file_exists(".github/workflows/altdoc.yaml"))
+  content <- .readlines(".github/workflows/altdoc.yaml")
+  expect_false(any(grepl("$ALTDOC_MKDOCS_START", content, fixed = TRUE)))
+  expect_true(any(grepl("install mkdocs", content, fixed = TRUE)))
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -38,3 +38,19 @@ test_that(".parse_news works", {
     all(sapply(should_be_found, grepl, x = parsed, fixed = TRUE))
   )
 })
+
+test_that(".which_license works", {
+  create_local_package()
+  fs::file_create("LICENSE.md")
+  expect_equal(.which_license(), "LICENSE.md")
+  fs::file_delete("LICENSE.md")
+  fs::file_create("LICENCE.md")
+  expect_equal(.which_license(), "LICENCE.md")
+  fs::file_delete("LICENCE.md")
+  expect_null(.which_license())
+})
+
+test_that(".find_head_branch works if no git", {
+  create_local_package()
+  expect_null(.find_head_branch())
+})


### PR DESCRIPTION
Mostly basic coverage for `.read_freeze()`, `.rd2qmd()` and `.qmd2md()`. 

The rendering functions are quite dense. Now that their behavior is a bit more stable we should refactor them to extract common helper functions that are easier to test.

Also minor changes:

* `setup_docs()` now directly errors if `altdoc` already exists and `overwrite = FALSE`
* better errors in `preview_docs()`