### PR TITLE
Do not try to write freeze.rds in CI workflows

### DIFF
--- a/R/import_man.R
+++ b/R/import_man.R
@@ -160,7 +160,11 @@
     writeLines(tmp, destination_md)
   }
 
-  .write_freeze(input = origin_Rd, path = src_dir, freeze = freeze, worked = worked)
+  # do not try to read/write the RDS file if we run in CI because the updated
+  # RDS won't be available to us anyway
+  if (!.on_ci()) {
+    .write_freeze(input = origin_Rd, path = src_dir, freeze = freeze, worked = worked)
+  }
 
   return(ifelse(worked, "success", "failure"))
 }

--- a/R/import_vignettes.R
+++ b/R/import_vignettes.R
@@ -113,7 +113,11 @@
       worked <- .qmd2md(origin, tar_dir, verbose = verbose, preamble = pre)
     }
 
-    .write_freeze(input = origin, path = src_dir, freeze = freeze, worked = worked)
+    # do not try to read/write the RDS file if we run in CI because the updated
+    # RDS won't be available to us anyway
+    if (!.on_ci()) {
+      .write_freeze(input = origin, path = src_dir, freeze = freeze, worked = worked)
+    }
 
     return(ifelse(worked, "success", "failure"))
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -196,3 +196,7 @@
   branch <- .readlines(".git/HEAD")
   gsub("^ref: refs/heads/", "", branch)
 }
+
+.on_ci <- function() {
+  isTRUE(as.logical(Sys.getenv("CI", "false")))
+}

--- a/tests/testthat/test-import_man.R
+++ b/tests/testthat/test-import_man.R
@@ -31,6 +31,8 @@ test_that("rendering skipped because internal", {
 })
 
 test_that("rendering skipped because unchanged and freeze = TRUE", {
+  # writing freeze.rds is disabled in CI
+  skip_on_ci()
   source <- test_path("examples/examples-man/between.Rd")
   dest <- tempfile(fileext = ".Rd")
   fs::file_copy(source, dest)


### PR DESCRIPTION
Keep getting an error about "can't read RDS" in the polars CI. Maybe it's just better to not write this file because it won't be updated in `main` and therefore not available to us