### PR TITLE
Update hashes all at once

### DIFF
--- a/R/freeze.R
+++ b/R/freeze.R
@@ -44,7 +44,7 @@
         if (i %in% files_success) {
             hashes[[i]] <- digest::digest(.readlines(i))
         } else if (i %in% files_fail) {
-            hashes[[i]] <- NULL
+            hashes <- hashes[names(hashes) != i]
         }
     }
     saveRDS(hashes, freeze_file)

--- a/R/import_man.R
+++ b/R/import_man.R
@@ -76,6 +76,9 @@
   fails <- which(conversion_worked == "failure")
   skipped_internal <- which(conversion_worked == "skipped_internal")
   skipped_unchanged <- which(conversion_worked == "skipped_unchanged")
+
+  .update_freeze(src_dir, man_source, successes, fails, type = "man")
+
   cli::cli_progress_done()
 
   # indent bullet points
@@ -163,12 +166,6 @@
     tmp <- .readlines(destination_md)
     tmp <- gsub("^##", "#", tmp)
     writeLines(tmp, destination_md)
-  }
-
-  # do not try to read/write the RDS file if we run in CI because the updated
-  # RDS won't be available to us anyway
-  if (!.on_ci()) {
-    .write_freeze(input = origin_Rd, src_dir = src_dir, freeze = freeze, worked = worked)
   }
 
   return(ifelse(worked, "success", "failure"))

--- a/R/import_vignettes.R
+++ b/R/import_vignettes.R
@@ -114,6 +114,9 @@
   successes <- which(conversion_worked == "success")
   fails <- which(conversion_worked == "failure")
   skipped_unchanged <- which(conversion_worked == "skipped_unchanged")
+
+  .update_freeze(src_dir, src_files, successes, fails, type = "vignettes")
+
   cli::cli_progress_done()
 
   if (length(skipped_unchanged) > 0) {
@@ -175,12 +178,6 @@
       pre <- NULL
     }
     worked <- .qmd2md(origin, tar_dir, verbose = verbose, preamble = pre)
-  }
-
-  # do not try to read/write the RDS file if we run in CI because the updated
-  # RDS won't be available to us anyway
-  if (!.on_ci()) {
-    .write_freeze(input = origin, src_dir = src_dir, freeze = freeze, worked = worked)
   }
 
   return(ifelse(worked, "success", "failure"))


### PR DESCRIPTION
Close #219 

I think the error when we have `freeze` + `parallel` is that we write to `freeze.rds` for each file individually, right after they're rendered. This is an issue when several processes want to write to the same file at the same time.

This PR *should* fix this by updating all hashes at once after all man pages (or vignettes) have been rendered.

@vincentarelbundock can you try with this branch to see if it solves #219?