### PR TITLE
Allow `freeze` for README

### DIFF
--- a/R/import_readme.R
+++ b/R/import_readme.R
@@ -1,57 +1,92 @@
-.import_readme <- function(src_dir, tar_dir, tool) {
+.import_readme <- function(src_dir, tar_dir, tool, freeze) {
 
-  # order is important. We want to prioritize .qmd, so we do it last.
+  # priorities: .qmd > .Rmd > .md
+  readme_files <- list.files(src_dir, pattern = "README")
 
-  # no extension -> md
-  fn <- fs::path_join(c(src_dir, "README"))
-  if (fs::file_exists(fn)) {
-    fs::file_copy(fn, fs::path_join(c(src_dir, "README.md")))
-  }
-
-  # rmd -> md
-  fn <- fs::path_join(c(src_dir, "README.Rmd"))
-  if (fs::file_exists(fn)) {
-    pre <- fs::path_join(c( src_dir, "altdoc/preamble_vignettes_rmd.yml"))
-    pre <- tryCatch(.readlines(pre), error = function(e) NULL)
-    .qmd2md(fn, src_dir, preamble = pre)
-  }
-
-  # qmd -> md
-  fn <- fs::path_join(c(src_dir, "README.qmd"))
-  if (fs::file_exists(fn)) {
-    pre <- fs::path_join(c(src_dir, "altdoc/preamble_vignettes_qmd.yml"))
-    if (fs::file_exists(pre)) {
-      pre <- tryCatch(.readlines(pre), error = function(e) NULL)
-    } else {
-      pre <- ""
-    }
-    if (tool == "quarto_website") {
-      # copy to quarto file
-      fs::file_copy(
-        fn,
-        fs::path_join(c(tar_dir, "index.qmd")),
-        overwrite = TRUE)
-      # process in-place for use on Github
-      # TODO: preambles inserted in the README often break Quarto websites. It's
-      # not a big problem to omit the preamble, but it would be good to
-      # investigate this, because I am not sure what is going on -VAB
-      .qmd2md(fn, src_dir)
-      # .qmd2md(fn, src_dir, preamble = pre)
-      cli::cli_alert_success("{.file README} imported.")
-      return(invisible())
-    } else {
-      .qmd2md(fn, src_dir)
-      # .qmd2md(fn, src_dir, preamble = pre)
-    }
-  } else if (tool == "quarto_website") {
-    cli::cli_abort("Quarto websites require a README.qmd file in the root of the package directory.", call = NULL)
-  }
-
-  # no README -> create a dummy
-  fn <- fs::path_join(c(src_dir, "README.md"))
-  if (!fs::file_exists(fn)) {
+  # no README -> create a dummy .qmd (choose .qmd because quarto requires a .qmd)
+  if (length(readme_files) == 0) {
+    fn <- fs::path_join(c(src_dir, "README.qmd"))
     writeLines(c("", "Hello world!"), fn)
+    readme_files <- "README.qmd"
   }
+
+  # Find the preferred README extension
+  readme_type <- if ("README.qmd" %in% readme_files) {
+    "qmd"
+  } else if ("README.Rmd" %in% readme_files) {
+    "rmd"
+  } else if ("README.md" %in% readme_files) {
+    "md"
+  } else if ("README" %in% readme_files) {
+    # no extension -> md
+    readme_files[readme_files == "README"] <- "README.md"
+    fs::file_move(
+      fs::path_join(c(src_dir, "README")),
+      fs::path_join(c(src_dir, "README.md"))
+    )
+    "md"
+  }
+
+  if (readme_type != "qmd" && tool == "quarto_website") {
+    cli::cli_abort(
+      "Quarto websites require a README.qmd file in the root of the package directory.",
+      call = NULL
+    )
+  }
+
+  src_file <- fs::path_join(
+    c(src_dir, grep(paste0("\\.", readme_type, "$"), readme_files, ignore.case = TRUE, value = TRUE))
+  )
+
+  # Skip file when frozen
+  if (isTRUE(freeze)) {
+    hashes <- .get_hashes(src_dir = src_dir, freeze = freeze)
+    flag <- .is_frozen(
+      input = basename(src_file),
+      output = fs::path_join(c(src_dir, "docs", "README.md")),
+      hashes = hashes
+    )
+    if (isTRUE(flag)) {
+      cli::cli_alert("Skipped {.file {basename(src_file)}} rendering because it didn't change.")
+      return(invisible())
+    }
+  }
+
+  # Render README if Rmd or qmd
+  # Do nothing if we only have a .md file
+  switch(
+    readme_type,
+
+    # rmd -> md
+    "rmd" = {
+        pre <- fs::path_join(c(src_dir, "altdoc/preamble_vignettes_rmd.yml"))
+        pre <- tryCatch(.readlines(pre), error = function(e) NULL)
+        .qmd2md(src_file, src_dir, preamble = pre)
+    },
+
+    # qmd -> md
+    "qmd" = {
+        pre <- fs::path_join(c(src_dir, "altdoc/preamble_vignettes_qmd.yml"))
+        pre <- tryCatch(.readlines(pre), error = function(e) NULL)
+        # copy to quarto file
+        if (tool == "quarto_website") {
+          fs::file_copy(
+            src_file,
+            fs::path_join(c(tar_dir, "index.qmd")),
+            overwrite = TRUE
+          )
+        }
+        # process in-place for use on Github
+        # TODO: preambles inserted in the README often break Quarto websites. It's
+        # not a big problem to omit the preamble, but it would be good to
+        # investigate this, because I am not sure what is going on -VAB
+        .qmd2md(src_file, src_dir)
+        # .qmd2md(fn, src_dir, preamble = pre)
+        .update_freeze(src_dir, basename(src_file), successes = 1, fails = NULL, type = "README")
+        cli::cli_alert_success("{.file README} imported.")
+        return(invisible())
+    }
+  )
 
   if (tool == "quarto_website") {
     tar_file <- fs::path_join(c(tar_dir, "index.md"))
@@ -60,13 +95,13 @@
   }
 
   src_file <- fs::path_join(c(src_dir, "README.md"))
-  fs::file_copy(fn, tar_file, overwrite = TRUE)
+  fs::file_copy(src_file, tar_file, overwrite = TRUE)
   .check_md_structure(tar_file)
 
   tmp <- fs::path_join(c(src_dir, "README.markdown_strict_files"))
   if (fs::dir_exists(tmp)) {
     cli::cli_alert("We recommend using a `knitr` option to set the path of your images to `man/figures/README-`. This would ensure that images are properly stored and displayed on multiple platforms like CRAN, Github, and on your `altdoc` website.")
   }
-
+  .update_freeze(src_dir, basename(src_file), successes = 1, fails = NULL, type = "README")
   cli::cli_alert_success("{.file README} imported.")
 }

--- a/R/import_readme.R
+++ b/R/import_readme.R
@@ -67,7 +67,7 @@
     # qmd -> md
     "qmd" = {
         pre <- fs::path_join(c(src_dir, "altdoc/preamble_vignettes_qmd.yml"))
-        pre <- tryCatch(.readlines(pre), error = function(e) NULL)
+        pre <- tryCatch(.readlines(pre), warning = function(w) NULL, error = function(e) NULL)
         # copy to quarto file
         if (tool == "quarto_website") {
           fs::file_copy(

--- a/R/render_docs.R
+++ b/R/render_docs.R
@@ -80,7 +80,7 @@ render_docs <- function(path = ".", verbose = FALSE, parallel = FALSE, freeze = 
   for (b in basics) {
     .import_basic(src_dir = path, tar_dir = docs_dir, name = b)
   }
-  .import_readme(src_dir = path, tar_dir = docs_dir, tool = tool)
+  .import_readme(src_dir = path, tar_dir = docs_dir, tool = tool, freeze = freeze)
   .import_citation(src_dir = path, tar_dir = docs_dir)
 
 

--- a/tests/testthat/test-import_man.R
+++ b/tests/testthat/test-import_man.R
@@ -45,6 +45,7 @@ test_that("rendering skipped because unchanged and freeze = TRUE", {
 
   # first rendering to store the hash
   .render_one_man(src, tool = "docute", src_dir = ".", tar_dir = ".", freeze = FALSE, hashes = NULL)
+  .update_freeze(".", src, successes = 1, fails = NULL, type = "man")
   hashes <- .get_hashes(".", freeze = TRUE)
 
   expect_equal(

--- a/tests/testthat/test-render_docs.R
+++ b/tests/testthat/test-render_docs.R
@@ -120,7 +120,7 @@ test_that("quarto: no error for basic workflow", {
   install.packages(".", repos = NULL, type = "source")
   fs::file_move("README.Rmd", "README.qmd") # special thing quarto
   setup_docs("quarto_website")
-  expect_no_error(render_docs())
+  expect_no_error(render_docs(verbose = .on_ci()))
 
   ### Quarto output changes depending on the version, I don't have a solution for
   ### now.

--- a/tests/testthat/test-render_docs.R
+++ b/tests/testthat/test-render_docs.R
@@ -100,33 +100,35 @@ test_that("mkdocs: main files are correct", {
   expect_snapshot(.readlines("docs/vignettes/test.md"), variant = "mkdocs")
 })
 
-### Quarto output changes depending on the version, I don't have a solution for
-### now.
 
-# test_that("quarto: main files are correct", {
-#   skip_on_cran()
-#
-#   ### setup: create a temp package using the structure of testpkg.altdoc
-#   path_to_example_pkg <- fs::path_abs(test_path("examples/testpkg.altdoc"))
-#   create_local_project()
-#   fs::dir_delete("R")
-#   fs::dir_copy(path_to_example_pkg, ".")
-#   all_files <- list.files("testpkg.altdoc", full.names = TRUE)
-#   for (i in all_files) {
-#     fs::file_move(i, ".")
-#   }
-#   fs::dir_delete("testpkg.altdoc")
-#
-#   ### generate docs
-#   install.packages(".", repos = NULL, type = "source")
-#   fs::file_move("README.Rmd", "README.qmd") # special thing quarto
-#   setup_docs("quarto_website")
-#   render_docs()
-#
-#   ### test
-#   expect_snapshot(.readlines("docs/index.html"))
-#   expect_snapshot(.readlines("docs/NEWS.html"))
-#   expect_snapshot(.readlines("docs/man/hello_base.html"))
-#   expect_snapshot(.readlines("docs/man/hello_r6.html"))
-#   expect_snapshot(.readlines("docs/vignettes/test.html"))
-# })
+
+test_that("quarto: no error for basic workflow", {
+  skip_on_cran()
+
+  ### setup: create a temp package using the structure of testpkg.altdoc
+  path_to_example_pkg <- fs::path_abs(test_path("examples/testpkg.altdoc"))
+  create_local_project()
+  fs::dir_delete("R")
+  fs::dir_copy(path_to_example_pkg, ".")
+  all_files <- list.files("testpkg.altdoc", full.names = TRUE)
+  for (i in all_files) {
+    fs::file_move(i, ".")
+  }
+  fs::dir_delete("testpkg.altdoc")
+
+  ### generate docs
+  install.packages(".", repos = NULL, type = "source")
+  fs::file_move("README.Rmd", "README.qmd") # special thing quarto
+  setup_docs("quarto_website")
+  expect_no_error(render_docs())
+
+  ### Quarto output changes depending on the version, I don't have a solution for
+  ### now.
+
+  ### test
+  # expect_snapshot(.readlines("docs/index.html"))
+  # expect_snapshot(.readlines("docs/NEWS.html"))
+  # expect_snapshot(.readlines("docs/man/hello_base.html"))
+  # expect_snapshot(.readlines("docs/man/hello_r6.html"))
+  # expect_snapshot(.readlines("docs/vignettes/test.html"))
+})

--- a/tests/testthat/test-render_docs.R
+++ b/tests/testthat/test-render_docs.R
@@ -104,6 +104,7 @@ test_that("mkdocs: main files are correct", {
 
 test_that("quarto: no error for basic workflow", {
   skip_on_cran()
+  skip_if(.is_windows() && .on_ci(), "Windows on CI")
 
   ### setup: create a temp package using the structure of testpkg.altdoc
   path_to_example_pkg <- fs::path_abs(test_path("examples/testpkg.altdoc"))


### PR DESCRIPTION
* `freeze = TRUE` now also skips the README
* refactor `.import_readme()`
* add test for basic workflow with `quarto_website`