### PR TITLE
preview_docs works on non-RStudio systems

### DIFF
--- a/R/preview_docs.R
+++ b/R/preview_docs.R
@@ -19,18 +19,11 @@
 #'
 preview_docs <- function(path = ".") {
   .assert_dependency("servr", install = TRUE)
-  .assert_dependency("rstudioapi", install = TRUE)
 
   tool <- .doc_type(path)
   if (.folder_is_empty(fs::path_join(c(path, "docs")))) {
     cli::cli_abort("You must render the docs before previewing them. Use {.code altdoc::render_docs()}.")
   }
 
-  if (rstudioapi::isAvailable()) {
-    servr::httw(fs::path_join(c(path, "docs")))
-  } else {
-    if (fs::file_exists(fs::path_abs("docs/index.html", start = path))) {
-      utils::browseURL(fs::path_abs("docs/index.html", start = path))
-    }
-  }
+  servr::httw(fs::path_join(c(path, "docs")))
 }


### PR DESCRIPTION
`urlBrowser()` is a useless call with docsify and docute, because we need a live server to display the website, so that just launches an empty browser.

But it turns out that `servr::httw` works perfectly fine, even in weird setups like mine: WSL Ubuntu on Windows.

This removes the `rstudioapi` check and calls this immediately.