### PR TITLE
mkdocs: more informative virtual environment message

### DIFF
--- a/R/setup_docs.R
+++ b/R/setup_docs.R
@@ -49,10 +49,12 @@ setup_docs <- function(tool, path = ".", overwrite = FALSE) {
     if (!.venv_exists(path)) {
       cli::cli_abort(
         c(
-          "`altdoc` needs `mkdocs` to be installed in a Python virtual environment.",
-          "i" = "Set up a Python venv: {.code python -m venv .venv_altdoc}",
-          "i" = "Activate the venv (depends on your OS): {.url https://docs.python.org/3/library/venv.html#how-venvs-work}.",
-          "i" = "Install `mkdocs`: {.code python3 -m pip install mkdocs}"
+          "x" = "`altdoc` needs `mkdocs` to be installed in a Python virtual environment. The best way to create the required {.code .venv_altdoc} directory depends on your development environment. On a unix-like system, it usually involves executing these commands from the root directory of your R package:",
+          " " = "",
+          " " = "python -m venv .venv_altdoc",
+          " " = ".venv_altdoc/bin/pip install mkdocs mkdocs-material",
+          " " = "",
+          "i" = "You can learn more at this link: {.url https://docs.python.org/3/library/venv.html#how-venvs-work}"
         )
       )
     }

--- a/R/setup_docs.R
+++ b/R/setup_docs.R
@@ -49,12 +49,19 @@ setup_docs <- function(tool, path = ".", overwrite = FALSE) {
     if (!.venv_exists(path)) {
       cli::cli_abort(
         c(
-          "x" = "`altdoc` needs `mkdocs` to be installed in a Python virtual environment. The best way to create the required {.code .venv_altdoc} directory depends on your development environment. On a unix-like system, it usually involves executing these commands from the root directory of your R package:",
+          "x" = "`altdoc` needs `mkdocs` to be installed in a Python virtual environment. The best way to create the required {.code .venv_altdoc} directory depends on your development environment. It usually involves executing commands like the following from the root directory of your R package.",
+          " " = "",
+          " " = "On Linux or MacOS:",
           " " = "",
           " " = "python -m venv .venv_altdoc",
           " " = ".venv_altdoc/bin/pip install mkdocs mkdocs-material",
           " " = "",
-          "i" = "You can learn more at this link: {.url https://docs.python.org/3/library/venv.html#how-venvs-work}"
+          " " = "On Windows:",
+          " " = "",
+          " " = "python -m venv .venv_altdoc",
+          " " = ".venv_altdoc\\Scripts\\pip.exe install mkdocs mkdocs-material",
+          " " = "",
+          "i" = " If these commands do not work or you want learn more, visit this link: {.url https://docs.python.org/3/library/venv.html#how-venvs-work}"
         )
       )
     }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 
+
 <img src="man/figures/altdoc_logo_web.png" height = "125"><br>
 
 <img src="https://github.com/etiennebacher/altdoc/workflows/R-CMD-check/badge.svg">
@@ -55,6 +56,7 @@ root directory of the package:
 setup_docs(tool = "docsify")
 # setup_docs(tool = "docute")
 # setup_docs(tool = "mkdocs")
+# setup_docs(tool = "quarto_website")
 
 ### Render the vignettes and man pages
 render_docs()
@@ -117,7 +119,7 @@ settings</a>
 </tr>
 <tr>
 <td>
-MkDocs
+Quarto
 </td>
 <td>
 <code>marginaleffects</code>

--- a/README.qmd
+++ b/README.qmd
@@ -55,6 +55,7 @@ A typical workflow with `altdoc` is to execute these commands from the root dire
 setup_docs(tool = "docsify")
 # setup_docs(tool = "docute")
 # setup_docs(tool = "mkdocs")
+# setup_docs(tool = "quarto_website")
 
 ### Render the vignettes and man pages
 render_docs()
@@ -89,7 +90,7 @@ The websites in this table were created using Altdoc:
     <td><a href="https://github.com/vincentarelbundock/modelsummary/tree/main/altdoc">Altdoc settings</a></td>
   </tr>
   <tr>
-    <td>MkDocs</td>
+    <td>Quarto</td>
     <td><code>marginaleffects</code></td>
     <td>🌐<a href="https://marginaleffects.com">marginaleffects.com</a></td>
     <td><a href="https://github.com/vincentarelbundock/marginaleffects/tree/main/altdoc">Altdoc Settings</a></td>

--- a/vignettes/get-started.Rmd
+++ b/vignettes/get-started.Rmd
@@ -40,21 +40,16 @@ library, meaning that you will first need to set up a Python virtual environment
 python -m venv .venv_altdoc
 ```
 
-You then need to activate this virtual environment and the way to do that 
-[depends on your OS](https://docs.python.org/3/library/venv.html#how-venvs-work):
+Then, you can now install `mkdocs` (and other libraries such as `mkdocs-material` if needed). The correct commands to run can depend on your environment. For example, on Linux or Mac, this command may work:
 
 ```bash
-# Windows
-.venv_altdoc\Scripts\activate.bat
-
-# Mac / Linux
-source .venv_altdoc/bin/activate
+.venv_altdoc/bin/pip install mkdocs mkdocs-material
 ```
-You can now install `mkdocs` (and other libraries such as `mkdocs-material` if 
-needed):
+
+On Windows, this might work:
 
 ```bash
-python3 -m pip install mkdocs mkdocs-material
+.venv_altdoc\Scripts\pip.exe install mkdocs mkdocs-material
 ```
 
 See the [`mkdocs`](https://www.mkdocs.org/user-guide/installation/) and


### PR DESCRIPTION
I was a bit confused by the error message about virtual environment for `mkdocs`, because it seemed like I did not in fact need to activate the environment, because `altdoc` took care of it automatically.

Here's a proposal for a more informative message. Note that the code is *not* enclosed in backticks. This allows users to select/copy/paste the lines from the error message directly in their consoles instead of typing them manually.

```shell
Error:
✖ `altdoc` needs `mkdocs` to be installed in a Python virtual environment. The best way to create the
  required `.venv_altdoc` directory depends on your development environment. On a unix-like system, it usually
  involves executing these commands from the root directory of your R package:
  
  python -m venv .venv_altdoc
  .venv_altdoc/bin/pip install mkdocs mkdocs-material
  
ℹ You can learn more at this link: <https://docs.python.org/3/library/venv.html#how-venvs-work>.
Run `rlang::last_trace()` to see where the error occurred.
```