### PR TITLE
mkdocs: remove the gitignore in "docs/vignettes" if there is one

### DIFF
--- a/R/settings_mkdocs.R
+++ b/R/settings_mkdocs.R
@@ -141,8 +141,8 @@
 
     fs::dir_delete(fs::path_join(c(path, "site")))
 
-    if (fs::file_exists(fs::path_join(c(path, "vignettes/.gitignore")))) {
-        fs::file_delete(fs::path_join(c(path, "vignettes/.gitignore")))
+    if (fs::file_exists(fs::path_join(c(.doc_path(path), "vignettes/.gitignore")))) {
+        fs::file_delete(fs::path_join(c(.doc_path(path), "vignettes/.gitignore")))
     }
 }
 

--- a/R/settings_mkdocs.R
+++ b/R/settings_mkdocs.R
@@ -128,7 +128,7 @@
     print(fs::dir_exists("docs/vignettes/install/index.html"))
 
     print("Dir tree")
-    print(fs::dir_tree("docs"))
+    print(fs::dir_tree("docs", all = TRUE))
 
     print("Root")
     print(getwd())

--- a/R/settings_mkdocs.R
+++ b/R/settings_mkdocs.R
@@ -140,6 +140,10 @@
     print(getwd())
 
     fs::dir_delete(fs::path_join(c(path, "site")))
+
+    if (fs::file_exists(fs::path_join(c(path, "vignettes/.gitignore")))) {
+        fs::file_delete(fs::path_join(c(path, "vignettes/.gitignore")))
+    }
 }
 
 

--- a/R/settings_mkdocs.R
+++ b/R/settings_mkdocs.R
@@ -87,6 +87,12 @@
     src <- fs::dir_ls(fs::path_join(c(path, "site/")), recurse = TRUE)
     tar <- sub("/site/", "/docs/", src)
 
+    path_with_dbl_path <- grep("r-polars/r-polars", tar, value = TRUE)
+    if (length(path_with_dbl_path) > 0) {
+        print("Several paths with double 'r-polars'")
+        print(path_with_dbl_path)
+    }
+
     print("Same length of src and tar:")
     print(length(src) == length(tar))
 

--- a/R/settings_mkdocs.R
+++ b/R/settings_mkdocs.R
@@ -85,6 +85,7 @@
     # move to docs/
     fs::file_move(fs::path_join(c(path, "mkdocs.yml")), .doc_path(path))
     src <- fs::dir_ls(fs::path_join(c(path, "site/")), recurse = TRUE)
+    src <- src[-grep("\\.gitignore$", src)]
     tar <- sub("/site/", "/docs/", src)
 
     path_with_dbl_path <- grep("r-polars/r-polars", tar, value = TRUE)

--- a/R/settings_mkdocs.R
+++ b/R/settings_mkdocs.R
@@ -87,12 +87,28 @@
     src <- fs::dir_ls(fs::path_join(c(path, "site/")), recurse = TRUE)
     tar <- sub("/site/", "/docs/", src)
 
+    print("Same length of src and tar:")
+    print(length(src) == length(tar))
+
+    print("File is in tar: docs/vignettes/install/index.html")
+    print(any(grepl("docs/vignettes/install/index.html", tar)))
+
     for (i in seq_along(src)) {
-        fs::dir_create(fs::path_dir(tar[i]))  # Create the directory if it doesn't exist
+
+        fs::dir_create(fs::path_dir(tar[i]))
+
+
         if (fs::is_file(src[i])) {
             fs::file_copy(src[i], tar[i], overwrite = TRUE)
         }
     }
+
+    print("Dir exists: docs/vignettes/install")
+    print(fs::dir_exists("docs/vignettes/install"))
+
+    print("File exists: docs/vignettes/install/index.html")
+    print(fs::dir_exists("docs/vignettes/install/index.html"))
+
     fs::dir_delete(fs::path_join(c(path, "site")))
 }
 

--- a/R/settings_mkdocs.R
+++ b/R/settings_mkdocs.R
@@ -85,7 +85,7 @@
     # move to docs/
     fs::file_move(fs::path_join(c(path, "mkdocs.yml")), .doc_path(path))
     src <- fs::dir_ls(fs::path_join(c(path, "site/")), recurse = TRUE)
-    src <- src[-grep("\\.gitignore$", src)]
+    # src <- src[-grep("\\.gitignore$", src)]
     tar <- sub("/site/", "/docs/", src)
 
     print(src)

--- a/R/settings_mkdocs.R
+++ b/R/settings_mkdocs.R
@@ -126,6 +126,12 @@
     print("File exists: docs/vignettes/install/index.html")
     print(fs::dir_exists("docs/vignettes/install/index.html"))
 
+    print("Dir tree")
+    print(fs::dir_tree("docs"))
+
+    print("Root")
+    print(getwd())
+
     fs::dir_delete(fs::path_join(c(path, "site")))
 }
 

--- a/R/settings_mkdocs.R
+++ b/R/settings_mkdocs.R
@@ -90,12 +90,19 @@
     print("Same length of src and tar:")
     print(length(src) == length(tar))
 
+    print("File is in src: site/vignettes/install/index.html")
+    print(any(grepl("site/vignettes/install/index.html", src)))
+
     print("File is in tar: docs/vignettes/install/index.html")
     print(any(grepl("docs/vignettes/install/index.html", tar)))
 
     for (i in seq_along(src)) {
 
         fs::dir_create(fs::path_dir(tar[i]))
+
+        if (grepl("site/vignettes/install/index.html", src[i])) {
+            print("site/vignettes/install/index.html is in the loop")
+        }
 
 
         if (fs::is_file(src[i])) {

--- a/R/settings_mkdocs.R
+++ b/R/settings_mkdocs.R
@@ -107,6 +107,10 @@
 
         if (fs::is_file(src[i])) {
             fs::file_copy(src[i], tar[i], overwrite = TRUE)
+            if (grepl("site/vignettes/install/index.html", src[i])) {
+                print("site/vignettes/install/index.html is copied")
+                print(tar[i])
+            }
         }
     }
 

--- a/R/settings_mkdocs.R
+++ b/R/settings_mkdocs.R
@@ -77,7 +77,7 @@
           paste0(
             "-c 'source ",
             fs::path_join(c(fs::path_abs(path), "/.venv_altdoc/bin/activate")),
-            " && python3 -m mkdocs build -q'"
+            " && python3 -m mkdocs build'"
           )
         )
     }
@@ -93,6 +93,9 @@
         print("Several paths with double 'r-polars'")
         print(path_with_dbl_path)
     }
+
+    print("Dir tree site/vignettes")
+    print(fs::dir_tree("site/vignettes"))
 
     print("Same length of src and tar:")
     print(length(src) == length(tar))

--- a/R/settings_mkdocs.R
+++ b/R/settings_mkdocs.R
@@ -77,7 +77,7 @@
           paste0(
             "-c 'source ",
             fs::path_join(c(fs::path_abs(path), "/.venv_altdoc/bin/activate")),
-            " && python3 -m mkdocs build'"
+            " && python3 -m mkdocs build -q'"
           )
         )
     }

--- a/R/settings_mkdocs.R
+++ b/R/settings_mkdocs.R
@@ -142,6 +142,7 @@
     fs::dir_delete(fs::path_join(c(path, "site")))
 
     if (fs::file_exists(fs::path_join(c(.doc_path(path), "vignettes/.gitignore")))) {
+        print("here")
         fs::file_delete(fs::path_join(c(.doc_path(path), "vignettes/.gitignore")))
     }
 }

--- a/R/settings_mkdocs.R
+++ b/R/settings_mkdocs.R
@@ -88,6 +88,9 @@
     src <- src[-grep("\\.gitignore$", src)]
     tar <- sub("/site/", "/docs/", src)
 
+    print(src)
+    print(tar)
+
     path_with_dbl_path <- grep("r-polars/r-polars", tar, value = TRUE)
     if (length(path_with_dbl_path) > 0) {
         print("Several paths with double 'r-polars'")
@@ -101,10 +104,10 @@
     print(length(src) == length(tar))
 
     print("File is in src: site/vignettes/install/index.html")
-    print(any(grepl("site/vignettes/install/index.html", src)))
+    print(any(grepl("site/vignettes/install/index.html", src, fixed = TRUE)))
 
     print("File is in tar: docs/vignettes/install/index.html")
-    print(any(grepl("docs/vignettes/install/index.html", tar)))
+    print(any(grepl("docs/vignettes/install/index.html", tar, fixed = TRUE)))
 
     for (i in seq_along(src)) {
 

--- a/R/settings_mkdocs.R
+++ b/R/settings_mkdocs.R
@@ -85,64 +85,21 @@
     # move to docs/
     fs::file_move(fs::path_join(c(path, "mkdocs.yml")), .doc_path(path))
     src <- fs::dir_ls(fs::path_join(c(path, "site/")), recurse = TRUE)
-    # src <- src[-grep("\\.gitignore$", src)]
     tar <- sub("/site/", "/docs/", src)
 
-    print(src)
-    print(tar)
-
-    path_with_dbl_path <- grep("r-polars/r-polars", tar, value = TRUE)
-    if (length(path_with_dbl_path) > 0) {
-        print("Several paths with double 'r-polars'")
-        print(path_with_dbl_path)
-    }
-
-    print("Dir tree site/vignettes")
-    print(fs::dir_tree("site/vignettes"))
-
-    print("Same length of src and tar:")
-    print(length(src) == length(tar))
-
-    print("File is in src: site/vignettes/install/index.html")
-    print(any(grepl("site/vignettes/install/index.html", src, fixed = TRUE)))
-
-    print("File is in tar: docs/vignettes/install/index.html")
-    print(any(grepl("docs/vignettes/install/index.html", tar, fixed = TRUE)))
-
     for (i in seq_along(src)) {
-
         fs::dir_create(fs::path_dir(tar[i]))
-
-        if (grepl("site/vignettes/install/index.html", src[i])) {
-            print("site/vignettes/install/index.html is in the loop")
-        }
-
-
         if (fs::is_file(src[i])) {
             fs::file_copy(src[i], tar[i], overwrite = TRUE)
-            if (grepl("site/vignettes/install/index.html", src[i])) {
-                print("site/vignettes/install/index.html is copied")
-                print(tar[i])
-            }
         }
     }
-
-    print("Dir exists: docs/vignettes/install")
-    print(fs::dir_exists("docs/vignettes/install"))
-
-    print("File exists: docs/vignettes/install/index.html")
-    print(fs::dir_exists("docs/vignettes/install/index.html"))
-
-    print("Dir tree")
-    print(fs::dir_tree("docs", all = TRUE))
-
-    print("Root")
-    print(getwd())
 
     fs::dir_delete(fs::path_join(c(path, "site")))
 
+    # for some reason, the folder "docs/vignettes" gets a gitignore that
+    # prevents HTML files to be committed so we remove it (happened several times
+    # in polars, see e.g https://github.com/pola-rs/r-polars/pull/646)
     if (fs::file_exists(fs::path_join(c(.doc_path(path), "vignettes/.gitignore")))) {
-        print("here")
         fs::file_delete(fs::path_join(c(.doc_path(path), "vignettes/.gitignore")))
     }
 }


### PR DESCRIPTION
I don't really know why, but sometimes there is a gitignore file in the "docs/vignettes" folder only that ignores `.R` and `.html` files. This is a problem because it means that the files created by mkdocs are not pushed at the end of the `altdoc` workflow, and therefore they direct to 404 on the deployed website.

This PR is a patch for that (I'm not sure why this gitignore appears)