### PR TITLE
Enable `freeze` functionality for `quarto_website`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,25 @@
 # News
 
+## dev
+
+### Breaking changes
+
+* Simplified rendering for Quarto websites. Previously, the website was rendered into `_quarto/_site` and manually copied over to `docs/`. The new version removes this logic and instead uses the `output-dir` project option. To transition, change `quarto_website.yml` to:
+  ``` yml
+  project:
+    output-dir: ../docs/
+  ```
+
+### New features
+
+* `render_docs(freeze = TRUE)` now works correctly when output is `"quarto_website"`. Freezing a document needs to be set either at a project or per-file level. To do so, add to either `quarto_website.yml` or the frontmatter of a file:
+  ``` yml
+  execute:
+    freeze: auto
+  ```
+
+
+
 ## 0.3.0
 
 All functions have changed so any change listed below technically is a breaking 

--- a/R/altdoc_variables.R
+++ b/R/altdoc_variables.R
@@ -5,7 +5,7 @@
     for (vn in files) {
         fn <- fs::path_join(c(.doc_path(path), vn))
         regex <- sprintf("\\$ALTDOC_%s", fs::path_ext_remove(basename(vn)))
-        if (fs::file_exists(fn) || fs::file_exists(fs::path_join(c(path, "_quarto/docs", vn)))) {
+        if (fs::file_exists(fn) || fs::file_exists(fs::path_join(c(path, "_quarto", vn)))) {
             if (tool == "docute") {
                 new <- paste0("/", vn)
             } else {

--- a/R/import_vignettes.R
+++ b/R/import_vignettes.R
@@ -39,9 +39,7 @@
 
   # target directory
   tar_dir <- fs::path_join(c(tar_dir, "vignettes"))
-  if (!dir.exists(tar_dir)) {
-    fs::dir_create(tar_dir)
-  }
+  fs::dir_create(tar_dir)
 
   # source files
   # docute can't open PDF in external tab because it adds ".md" after all files

--- a/R/render_docs.R
+++ b/R/render_docs.R
@@ -61,13 +61,10 @@ render_docs <- function(path = ".", verbose = FALSE, parallel = FALSE, freeze = 
     # Delete everything in `_quarto/` besides `_freeze/`
     if (fs::dir_exists(docs_dir)) {
       docs_files = fs::dir_ls(docs_dir)
-
-      for (f in docs_files) {
-        if (freeze == FALSE || basename(f) != "_freeze") {
-          if (fs::is_dir(f)) fs::dir_delete(f)
-          if (fs::is_file(f)) fs::file_delete(f)
-        }
-      }
+      if (freeze == TRUE) {
+        docs_files = Filter(function(f) basename(f) != "_freeze", docs_files)
+      } 
+      fs::file_delete(docs_files)
     }
 
     .add_gitignore("_quarto/", path = path)

--- a/R/render_docs.R
+++ b/R/render_docs.R
@@ -58,11 +58,17 @@ render_docs <- function(path = ".", verbose = FALSE, parallel = FALSE, freeze = 
   if (tool == "quarto_website") {
     docs_dir <- fs::path_join(c(path, "_quarto"))
 
-    # TODO: Delete every folder besides _freeze/
-    # # avoid collisions
-    # if (fs::dir_exists(docs_dir)) {
-    #   fs::dir_delete(docs_dir)
-    # }
+    # Delete everything in `_quarto/` besides `_freeze/`
+    if (fs::dir_exists(docs_dir)) {
+      docs_files = fs::dir_ls(docs_dir)
+
+      for (f in docs_files) {
+        if (freeze == FALSE || basename(f) != "_freeze") {
+          if (fs::is_dir(f)) fs::dir_delete(f)
+          if (fs::is_file(f)) fs::file_delete(f)
+        }
+      }
+    }
 
     .add_gitignore("_quarto/", path = path)
     .add_gitignore("!_quarto/_freeze/", path = path)
@@ -75,6 +81,7 @@ render_docs <- function(path = ".", verbose = FALSE, parallel = FALSE, freeze = 
     fs::dir_create(docs_dir)
   }
 
+  # TODO: freeze functionality should not apply to qaurto websites; instead freeze functionality should be toggled via quarto tools (either in `quarto_website.yml` or on a per file basis. Use `execute:\n\t freeze: auto` in the yml to do this.)
   cli::cli_h1("Basic files")
   
   basics <- c("NEWS", "CHANGELOG", "ChangeLog", "CODE_OF_CONDUCT", "LICENSE", "LICENCE")

--- a/R/render_docs.R
+++ b/R/render_docs.R
@@ -31,6 +31,7 @@
 #' @return NULL
 #' @template altdoc_variables
 #' @template altdoc_preambles
+#' @template altdoc_freeze
 #'
 #' @examples
 #' if (interactive()) {

--- a/R/render_docs.R
+++ b/R/render_docs.R
@@ -76,14 +76,10 @@ render_docs <- function(path = ".", verbose = FALSE, parallel = FALSE, freeze = 
     docs_dir <- fs::path_join(c(path, "docs"))
   }
 
-  # create docs/
-  if (!fs::dir_exists(docs_dir)) {
-    fs::dir_create(docs_dir)
-  }
+  # create `docs_dir/`
+  fs::dir_create(docs_dir)
 
-  # TODO: freeze functionality should not apply to qaurto websites; instead freeze functionality should be toggled via quarto tools (either in `quarto_website.yml` or on a per file basis. Use `execute:\n\t freeze: auto` in the yml to do this.)
-  cli::cli_h1("Basic files")
-  
+  cli::cli_h1("Basic files")  
   basics <- c("NEWS", "CHANGELOG", "ChangeLog", "CODE_OF_CONDUCT", "LICENSE", "LICENCE")
   for (b in basics) {
     .import_basic(src_dir = path, tar_dir = docs_dir, name = b)

--- a/R/render_docs.R
+++ b/R/render_docs.R
@@ -60,9 +60,9 @@ render_docs <- function(path = ".", verbose = FALSE, parallel = FALSE, freeze = 
 
     # Delete everything in `_quarto/` besides `_freeze/`
     if (fs::dir_exists(docs_dir)) {
-      docs_files = fs::dir_ls(docs_dir)
+      docs_files <- fs::dir_ls(docs_dir)
       if (freeze == TRUE) {
-        docs_files = Filter(function(f) basename(f) != "_freeze", docs_files)
+        docs_files <- Filter(function(f) basename(f) != "_freeze", docs_files)
       } 
       fs::file_delete(docs_files)
     }

--- a/R/render_docs.R
+++ b/R/render_docs.R
@@ -56,24 +56,27 @@ render_docs <- function(path = ".", verbose = FALSE, parallel = FALSE, freeze = 
   # build quarto in a separate folder to use the built-in freeze functionality
   # and to allow moving the _site folder to docs/
   if (tool == "quarto_website") {
-    docs_parent <- fs::path_join(c(path, "_quarto"))
-    # avoid collisions
-    if (fs::dir_exists(docs_parent)) {
-      fs::dir_delete(docs_parent)
-    }
-    .add_gitignore("^_quarto$", path = path)
+    docs_dir <- fs::path_join(c(path, "_quarto"))
+
+    # TODO: Delete every folder besides _freeze/
+    # # avoid collisions
+    # if (fs::dir_exists(docs_dir)) {
+    #   fs::dir_delete(docs_dir)
+    # }
+
+    .add_gitignore("_quarto/", path = path)
+    .add_gitignore("!_quarto/_freeze/", path = path)
   } else {
-    docs_parent <- path
+    docs_dir <- fs::path_join(c(path, "docs"))
   }
 
   # create docs/
-  docs_dir <- fs::path_join(c(docs_parent, "docs"))
   if (!fs::dir_exists(docs_dir)) {
     fs::dir_create(docs_dir)
   }
 
   cli::cli_h1("Basic files")
-
+  
   basics <- c("NEWS", "CHANGELOG", "ChangeLog", "CODE_OF_CONDUCT", "LICENSE", "LICENCE")
   for (b in basics) {
     .import_basic(src_dir = path, tar_dir = docs_dir, name = b)

--- a/R/settings.R
+++ b/R/settings.R
@@ -18,7 +18,7 @@
 
         # docs/* files are mutable and should be overwritten
         if (grepl("^quarto", tool)) {
-            tar_dir <- fs::path_join(c(path, "_quarto/docs"))
+            tar_dir <- fs::path_join(c(path, "_quarto"))
         } else {
             tar_dir <- .doc_path(path)
         }

--- a/R/settings_quarto_website.R
+++ b/R/settings_quarto_website.R
@@ -26,12 +26,12 @@
         fs::file_delete(b)
     }
 
-    # Clear out `docs_path`
     tar <- .doc_path(path)
     fs::dir_create(tar)
 
     # CNAME is used by Github and other providers to redirect to a custom domain
     files <- Filter(function(f) basename(f) != "CNAME", fs::dir_ls(tar))
+    # Clear out `tar`
     fs::file_delete(files)
 
     # render to `output-dir: ../docs/`
@@ -47,6 +47,8 @@
     # did not have the static files, and we want the static files in altdoc/ to
     # be served on the website. This a core feature of altdoc: users can store
     # files in altdoc/ and those will be copied to the root of the website
+
+    # this can be done automatically with `project:` > `resources: ../altdoc/` 
     fs::dir_copy(fs::path_join(c(path, "altdoc")), tar, overwrite = TRUE)
 
 }

--- a/R/settings_quarto_website.R
+++ b/R/settings_quarto_website.R
@@ -5,11 +5,11 @@
 
     # drop empty lines
     settings <- settings[!grepl("^\\w*$", settings)]
-    settings = yaml::as.yaml(
+    settings <- yaml::as.yaml(
       settings, indent.mapping.sequence = TRUE, 
       handler = list(logical = yaml::verbatim_logical)
     )
-    settings = strsplit(settings, "\\n")[[1]]
+    settings <- strsplit(settings, "\\n")[[1]]
     writeLines(settings, fs::path_join(c(path, "_quarto", "_quarto.yml")))
 
     # index.md breaks rendering
@@ -31,7 +31,7 @@
     fs::dir_create(tar)
 
     # CNAME is used by Github and other providers to redirect to a custom domain
-    files = Filter(function(f) basename(f) != "CNAME", fs::dir_ls(tar))
+    files <- Filter(function(f) basename(f) != "CNAME", fs::dir_ls(tar))
     fs::file_delete(files)
 
     # render to `output-dir: ../docs/`

--- a/R/settings_quarto_website.R
+++ b/R/settings_quarto_website.R
@@ -28,16 +28,11 @@
 
     # Clear out `docs_path`
     tar <- .doc_path(path)
-    if (!fs::dir_exists(tar)) {
-      fs::dir_create(tar)
-    }
-    for (f in fs::dir_ls(tar)) {
-        # CNAME is used by Github and other providers to redirect to a custom domain
-        if (basename(f) != "CNAME") {
-            if (fs::is_dir(f)) fs::dir_delete(f)
-            if (fs::is_file(f)) fs::file_delete(f)
-        }
-    }
+    fs::dir_create(tar)
+
+    # CNAME is used by Github and other providers to redirect to a custom domain
+    files = Filter(function(f) basename(f) != "CNAME", fs::dir_ls(tar))
+    fs::file_delete(files)
 
     # render to `output-dir: ../docs/`
     quarto::quarto_render(

--- a/R/settings_quarto_website.R
+++ b/R/settings_quarto_website.R
@@ -5,15 +5,12 @@
 
     # drop empty lines
     settings <- settings[!grepl("^\\w*$", settings)]
-    
-    fn <- fs::path_join(c(path, "_quarto", "_quarto.yml"))
-    yaml::write_yaml(settings, fn, indent.mapping.sequence = TRUE)
-
-    # yaml::write_yaml converts true to yes, but quarto complains
-    settings <- .readlines(fn)
-    settings <- gsub(": yes$", ": true", settings)
-    settings <- gsub(": no$", ": false", settings)
-    writeLines(settings, fn)
+    settings = yaml::as.yaml(
+      settings, indent.mapping.sequence = TRUE, 
+      handler = list(logical = yaml::verbatim_logical)
+    )
+    settings = strsplit(settings, "\\n")[[1]]
+    writeLines(settings, fs::path_join(c(path, "_quarto", "_quarto.yml")))
 
     # index.md breaks rendering
     fn <- fs::path_join(c(path, "_quarto", "index.md"))

--- a/R/setup_github_actions.R
+++ b/R/setup_github_actions.R
@@ -17,10 +17,7 @@
 setup_github_actions <- function(path = ".") {
 
   path <- .convert_path(path)
-
-  if (!fs::dir_exists(fs::path_join(c(path, ".github/workflows")))) {
-    fs::dir_create(fs::path_join(c(path, ".github/workflows")))
-  }
+  fs::dir_create(fs::path_join(c(path, ".github/workflows")))
   if (fs::file_exists(fs::path_join(c(path, ".github/workflows/altdoc.yaml")))) {
     cli::cli_abort("{.file .github/workflows/altdoc.yaml} already exists.")
   }

--- a/inst/quarto_website/quarto_website.yml
+++ b/inst/quarto_website/quarto_website.yml
@@ -1,5 +1,10 @@
 project:
   type: website
+  output-dir: ../docs/
+
+# Note: freeze functionality can be set at a project level or for individual .qmd files
+# execute:
+#   freeze: false
 
 website:
   title: "$ALTDOC_PACKAGE_NAME"

--- a/man-roxygen/altdoc_freeze.R
+++ b/man-roxygen/altdoc_freeze.R
@@ -1,0 +1,12 @@
+#' @section Freeze
+#' 
+#' When working on a package, running `render_docs()` to preview changes can be a time-consuming road block. The argument `freeze = TRUE` tries to improve the experience by preventing rerendering of files that have not changed since the last time `render_docs()` was ran. Note that changes to package internals will not cause a rerender, so rerendering the entire docs can still be necessary. 
+#' 
+#' For non-Quarto formats, this is done by creating a `freeze.rds` file in `altdoc/` that is able to determine which documentation files have changed. 
+#' 
+#' For the Quarto format, we rely on the [Quarto freeze](https://quarto.org/docs/projects/code-execution.html#freeze) feature. Freezing a document needs to be set either at a project or per-file level. Freezing a document needs to be set either at a project or per-file level. To do so, add to either `quarto_website.yml` or the frontmatter of a file:
+#'  ``` yml
+#'  execute:
+#'    freeze: auto
+#'  ```
+#' 


### PR DESCRIPTION
This PR enables the use of [`freeze`](https://quarto.org/docs/projects/code-execution.html#freeze) functionality for `_quarto` websites. To enable freezing results of a file, add the following yml either to `quarto_website.yml` to enable site-wide or to the frontmatter of individual `.qmd` files:
``` yml
execute:
  freeze: auto
```

The rendering logic is changed just a bit to render directly into `docs/`. For packages using `altdoc`, after this change, you need to add `output-dir` to your `quarto_website.yml`:
``` yml
project:
  type: website
  output-dir: ../docs
```

Also fixed the annoying converting `: yes` to `: true`; there's a feature in `yaml` package