### PR TITLE
Show error messages from quarto even if `verbose = FALSE`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,7 @@ BugReports: https://github.com/etiennebacher/altdoc/issues
 Imports: 
     cli,
     desc,
+    evaluate,
     fs,
     quarto,
     tools,


### PR DESCRIPTION
https://github.com/etiennebacher/altdoc/issues/270#issuecomment-2038185857

We already install `evaluate` anyway since it's one of the foundations of quarto/R Markdown:

``` r
pak::pkg_deps_explain("altdoc", "evaluate")
#> ℹ Loading metadata database✔ Loading metadata database ... done
#> altdoc -> quarto -> rmarkdown -> evaluate
#> altdoc -> quarto -> rmarkdown -> knitr -> evaluate
```

## Demo

On a small test R package with 2 man pages, one of which has an error.

### Before

```r
> altdoc::render_docs(verbose = FALSE)

── Basic files ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────
✔ README imported.

── Man pages ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
ℹ Found 2 man pages to convert.
✔ Converting function reference 1/2: hello_base [2.3s]
✔ Converting function reference 2/2: hello_r6 [897ms]

✖ The conversion failed for the following man page:
  • hello_base

── Vignettes ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
ℹ Found 2 vignettes to convert.
✔ Converting vignette 1/2: altdoc.pdf [41ms]
✔ Converting vignette 2/2: test.Rmd [1.9s]
Error in `altdoc::render_docs()`:
! There were some failures when rendering man pages.
Run `rlang::last_trace()` to see where the error occurred.
```

### After

Note that if there are no error (man page number 2), then there are no quarto messages at all:

```r
> altdoc::render_docs(verbose = FALSE)

── Basic files ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────
✔ README imported.

── Man pages ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
ℹ Found 2 man pages to convert.
⠙ Converting function reference 1/2: hello_base

processing file: hello_base.qmd
  |...................................                 |  67% [unnamed-chunk-1]


Quitting from lines 40-44 [unnamed-chunk-1] (hello_base.qmd)
Error in `log()`:
! non-numeric argument to mathematical function
                                                                                                            
Execution halted
✔ Converting function reference 1/2: hello_base [2.3s]
✔ Converting function reference 2/2: hello_r6 [887ms]

✖ The conversion failed for the following man page:
  • hello_base

── Vignettes ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
ℹ Found 2 vignettes to convert.
✔ Converting vignette 1/2: altdoc.pdf [32ms]
✔ Converting vignette 2/2: test.Rmd [1.9s]
Error in `altdoc::render_docs()`:
! There were some failures when rendering man pages.
Run `rlang::last_trace()` to see where the error occurred.
```
