### PR TITLE
evalutate::evaluate opens a new graphic device on every convert

### DIFF
--- a/R/qmd2md.R
+++ b/R/qmd2md.R
@@ -32,8 +32,8 @@
       input = path.expand(tar_file),
       output_format = "md",
       quiet = FALSE,
-      as_job = FALSE
-    )')
+      as_job = FALSE,
+    )', new_device = FALSE)
     is_error <- vapply(
       out,
       function(x) inherits(x, c("error", "rlang_error")),


### PR DESCRIPTION
Trivial PR.

The recent addition of evaluate::evaluate() opened a new graphics device (window) every time we converted a file (sometimes hundreds of times for complex packages).

This is a one argument trivial change.