### PR TITLE
fix: does not require README.qmd for Quarto website

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,6 @@ License: MIT + file LICENSE
 URL: https://altdoc.etiennebacher.com, https://github.com/etiennebacher/altdoc
 BugReports: https://github.com/etiennebacher/altdoc/issues
 Imports: 
-    brio,
     cli,
     desc,
     evaluate,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,7 @@ License: MIT + file LICENSE
 URL: https://altdoc.etiennebacher.com, https://github.com/etiennebacher/altdoc
 BugReports: https://github.com/etiennebacher/altdoc/issues
 Imports: 
+    brio,
     cli,
     desc,
     evaluate,

--- a/R/import_readme.R
+++ b/R/import_readme.R
@@ -65,10 +65,6 @@
         # not a big problem to omit the preamble, but it would be good to
         # investigate this, because I am not sure what is going on -VAB
         .qmd2md(src_file, src_dir)
-        # .qmd2md(fn, src_dir, preamble = pre)
-        .update_freeze(src_dir, basename(src_file), successes = 1, fails = NULL, type = "README")
-        cli::cli_alert_success("{.file README} imported.")
-        return(invisible())
     }
   )
 

--- a/R/import_readme.R
+++ b/R/import_readme.R
@@ -75,8 +75,8 @@
 
   # Add the index page which includes README.md
   if (tool == "quarto_website") {
-    brio::write_lines(
-      "{{< include README.md >}}",
+    writeLines(
+      enc2utf8("{{< include README.md >}}"),
       fs::path_join(c(tar_dir, "index.md"))
     )
   }

--- a/R/settings_quarto_website.R
+++ b/R/settings_quarto_website.R
@@ -12,12 +12,6 @@
     settings <- strsplit(settings, "\\n")[[1]]
     writeLines(settings, fs::path_join(c(path, "_quarto", "_quarto.yml")))
 
-    # index.md breaks rendering
-    fn <- fs::path_join(c(path, "_quarto", "index.md"))
-    if (fs::file_exists(fn)) {
-        fs::file_delete(fn)
-    }
-
     # NEWS.qmd breaks rendering, so we delete it if NEWS.md is available.
     # This happens when converting from NEWS.Rd
     a <- fs::path_join(c(path, "_quarto", "NEWS.md"))

--- a/R/setup_docs.R
+++ b/R/setup_docs.R
@@ -164,11 +164,7 @@ setup_docs <- function(tool, path = ".", overwrite = FALSE) {
   }
 
   # README.md is mandatory
-  if (tool == "quarto_website") {
-    fn <- "README.qmd"
-  } else {
-    fn <- "README.md"
-  }
+  fn <- "README.md"
   msg <- sprintf("%s is mandatory. `altdoc` created a dummy README file in the package directory.", fn)
   fn <- fs::path_join(c(path, fn))
   if (!fs::file_exists(fn)) {

--- a/inst/quarto_website/quarto_website.yml
+++ b/inst/quarto_website/quarto_website.yml
@@ -19,7 +19,7 @@ website:
     collapse-level: 1
     contents:
       - text: Home
-        file: index.qmd
+        file: index.md
       - section: $ALTDOC_VIGNETTE_BLOCK
       - section: $ALTDOC_MAN_BLOCK
       - text: News

--- a/tests/testthat/test-setup_docs.R
+++ b/tests/testthat/test-setup_docs.R
@@ -61,6 +61,5 @@ test_that("quarto: README.qmd", {
   create_local_package()
   expect_false(file.exists("README.qmd"))
   setup_docs("quarto_website", overwrite = TRUE)
-  expect_true(file.exists("README.qmd"))
+  expect_false(file.exists("README.qmd"))
 })
-


### PR DESCRIPTION
Fix #292

I don't know if ideally we should render README.Rmd / qmd, but we should be able to fix the error for now anyway.