### PR TITLE
Add `output_path` argument to `render_docs()`

### DIFF
--- a/R/render_docs.R
+++ b/R/render_docs.R
@@ -77,7 +77,7 @@ render_docs <- function(
   # build quarto in a separate folder to use the built-in freeze functionality
   # and to allow moving the _site folder to docs/
   if (tool == "quarto_website") {
-    docs_dir <- fs::path_join(c(output_path, "_quarto"))
+    docs_dir <- fs::path_join(c(path, "_quarto"))
 
     # Delete everything in `_quarto/` besides `_freeze/`
     if (fs::dir_exists(docs_dir)) {
@@ -88,10 +88,9 @@ render_docs <- function(
       fs::file_delete(docs_files)
     }
   } else {
-    docs_dir <- fs::path_join(c(output_path, "docs"))
+    docs_dir <- fs::path_join(c(path, "docs"))
   }
 
-  # create `docs_dir/`
   fs::dir_create(docs_dir)
 
   cli::cli_h1("Basic files")
@@ -102,15 +101,11 @@ render_docs <- function(
   .import_readme(src_dir = path, tar_dir = docs_dir, tool = tool, freeze = freeze)
   .import_citation(src_dir = path, tar_dir = docs_dir)
 
-
-  # Update functions reference
   cli::cli_h1("Man pages")
   fail_man <- .import_man(src_dir = path, tar_dir = docs_dir, tool = tool, verbose = verbose, parallel = parallel, freeze = freeze)
 
-  # Update vignettes
   cli::cli_h1("Vignettes")
   fail_vignettes <- .import_vignettes(src_dir = path, tar_dir = docs_dir, tool = tool, verbose = verbose, parallel = parallel, freeze = freeze)
-
 
   # Error so that CI fails
   if (length(fail_vignettes) > 0 & length(fail_man) > 0) {
@@ -123,6 +118,11 @@ render_docs <- function(
 
   cli::cli_h1("Update HTML")
   .import_settings(path = path, tool = tool, verbose = verbose, freeze = freeze)
+
+  if (path != ".") {
+    fs::dir_copy(fs::path(path, "docs"), fs::path(output_path, "docs"))
+    fs::dir_delete(fs::path(path, "docs"))
+  }
 
   cli::cli_h1("Complete")
   cli::cli_alert_success("Documentation updated.")

--- a/R/render_docs.R
+++ b/R/render_docs.R
@@ -119,7 +119,7 @@ render_docs <- function(
   cli::cli_h1("Update HTML")
   .import_settings(path = path, tool = tool, verbose = verbose, freeze = freeze)
 
-  if (path != ".") {
+  if (output_path != path) {
     fs::dir_copy(fs::path(path, "docs"), fs::path(output_path, "docs"))
     fs::dir_delete(fs::path(path, "docs"))
   }

--- a/R/settings.R
+++ b/R/settings.R
@@ -1,4 +1,4 @@
-.import_settings <- function(path = ".", tar_dir, tool = "docsify", verbose = FALSE, freeze = FALSE) {
+.import_settings <- function(path = ".", tool = "docsify", verbose = FALSE, freeze = FALSE) {
   # copy all files from altdoc/ into docs/
   # this allows users to store arbitrary and settings static files in altdoc/
   src <- fs::path_abs(fs::path_join(c(path, "altdoc")))
@@ -17,9 +17,9 @@
 
     # docs/* files are mutable and should be overwritten
     if (grepl("^quarto", tool)) {
-      tar_dir <- fs::path_join(c(tar_dir, "_quarto"))
+      tar_dir <- fs::path_join(c(path, "_quarto"))
     } else {
-      tar_dir <- .doc_path(tar_dir)
+      tar_dir <- .doc_path(path)
     }
 
     fs::dir_copy(src, tar_dir, overwrite = TRUE)

--- a/R/settings.R
+++ b/R/settings.R
@@ -1,61 +1,64 @@
-.import_settings <- function(path = ".", tool = "docsify", verbose = FALSE, freeze = FALSE) {
+.import_settings <- function(path = ".", tar_dir, tool = "docsify", verbose = FALSE, freeze = FALSE) {
+  # copy all files from altdoc/ into docs/
+  # this allows users to store arbitrary and settings static files in altdoc/
+  src <- fs::path_abs(fs::path_join(c(path, "altdoc")))
+  if (fs::dir_exists(src)) {
+    files <- fs::dir_ls(src)
 
-    # copy all files from altdoc/ into docs/
-    # this allows users to store arbitrary and settings static files in altdoc/
-    src <- fs::path_abs(fs::path_join(c(path, "altdoc")))
-    if (fs::dir_exists(src)) {
-        files <- fs::dir_ls(src)
+    files <- files[!grepl("freeze.rds$", files)]
 
-        files <- files[!grepl("freeze.rds$", files)]
-
-        # hidden files not detected
-        fn <- fs::path_join(c(path, "altdoc/.nojekyll"))
-        if (fs::file_exists(fn)) {
-            files <- c(files, fn)
-        }
-
-        files <- files[!grepl("docute.html$|docsify.md$|mkdocs.yml$", files)]
-
-        # docs/* files are mutable and should be overwritten
-        if (grepl("^quarto", tool)) {
-            tar_dir <- fs::path_join(c(path, "_quarto"))
-        } else {
-            tar_dir <- .doc_path(path)
-        }
-
-        fs::dir_copy(src, tar_dir, overwrite = TRUE)
+    # hidden files not detected
+    fn <- fs::path_join(c(path, "altdoc/.nojekyll"))
+    if (fs::file_exists(fn)) {
+      files <- c(files, fn)
     }
 
-    fn <- switch(tool,
-        docsify = "docsify.md",
-        docute = "docute.html",
-        mkdocs = "mkdocs.yml",
-        quarto_website = "quarto_website.yml")
-    fn <- fs::path_join(c(path, "altdoc", fn))
-    settings <- .readlines(fn)
+    files <- files[!grepl("docute.html$|docsify.md$|mkdocs.yml$", files)]
 
-    settings <- .substitute_altdoc_variables(settings, path = path, tool = tool)
+    # docs/* files are mutable and should be overwritten
+    if (grepl("^quarto", tool)) {
+      tar_dir <- fs::path_join(c(tar_dir, "_quarto"))
+    } else {
+      tar_dir <- .doc_path(tar_dir)
+    }
 
-    vignettes <- switch(tool,
-        docsify = .sidebar_vignettes_docsify,
-        docute = .sidebar_vignettes_docute,
-        mkdocs = .sidebar_vignettes_mkdocs,
-        quarto_website = .sidebar_vignettes_quarto_website)
-    settings <- vignettes(sidebar = settings, path = path)
+    fs::dir_copy(src, tar_dir, overwrite = TRUE)
+  }
 
-    man <- switch(tool,
-        docsify = .sidebar_man_docsify,
-        docute = .sidebar_man_docute,
-        mkdocs = .sidebar_man_mkdocs,
-        quarto_website = .sidebar_man_quarto_website)
-    settings <- man(settings, path)
+  fn <- switch(tool,
+    docsify = "docsify.md",
+    docute = "docute.html",
+    mkdocs = "mkdocs.yml",
+    quarto_website = "quarto_website.yml"
+  )
+  fn <- fs::path_join(c(path, "altdoc", fn))
+  settings <- .readlines(fn)
 
-    finalize <- switch(tool,
-        docsify = .finalize_docsify,
-        docute = .finalize_docute,
-        mkdocs = .finalize_mkdocs,
-        quarto_website = .finalize_quarto_website)
-    settings <- finalize(settings, path, verbose, freeze)
+  settings <- .substitute_altdoc_variables(settings, path = path, tool = tool)
 
-    cli::cli_alert_success("HTML updated.")
+  vignettes <- switch(tool,
+    docsify = .sidebar_vignettes_docsify,
+    docute = .sidebar_vignettes_docute,
+    mkdocs = .sidebar_vignettes_mkdocs,
+    quarto_website = .sidebar_vignettes_quarto_website
+  )
+  settings <- vignettes(sidebar = settings, path = path)
+
+  man <- switch(tool,
+    docsify = .sidebar_man_docsify,
+    docute = .sidebar_man_docute,
+    mkdocs = .sidebar_man_mkdocs,
+    quarto_website = .sidebar_man_quarto_website
+  )
+  settings <- man(settings, path)
+
+  finalize <- switch(tool,
+    docsify = .finalize_docsify,
+    docute = .finalize_docute,
+    mkdocs = .finalize_mkdocs,
+    quarto_website = .finalize_quarto_website
+  )
+  settings <- finalize(settings, path, verbose, freeze)
+
+  cli::cli_alert_success("HTML updated.")
 }

--- a/R/settings_docsify.R
+++ b/R/settings_docsify.R
@@ -1,88 +1,88 @@
 .finalize_docsify <- function(settings, path, ...) {
+  tool <- .doc_type(path)
 
-    tool <- .doc_type(path)
+  # drop missing links
+  settings <- settings[!grepl("\\]\\(\\)", settings)]
+  settings <- stats::na.omit(settings)
 
-    # drop missing links
-    settings <- settings[!grepl("\\]\\(\\)", settings)]
-    settings <- stats::na.omit(settings)
-
-    fn_man <- fs::path_join(c(.doc_path(path), "reference.md"))
-    dn_man <- fs::path_join(c(.doc_path(path), "man"))
+  fn_man <- fs::path_join(c(.doc_path(path), "reference.md"))
+  dn_man <- fs::path_join(c(.doc_path(path), "man"))
 
 
-    fn <- fs::path_join(c(.doc_path(path), "_sidebar.md"))
-    writeLines(settings, fn)
+  fn <- fs::path_join(c(.doc_path(path), "_sidebar.md"))
+  writeLines(settings, fn)
 
-    # relative links
-    dn <- fs::path_join(c(path, "docs", "vignettes"))
-    if (fs::dir_exists(dn)) {
-        md_files <- fs::dir_ls(dn, regexp = "\\.md$")
-        for (md in md_files) {
-            src <- sprintf('src="%s.markdown_strict_files', gsub("\\.md$|\\.pdf$", "", basename(md)))
-            tar <- sprintf('src="vignettes/%s.markdown_strict_files', gsub("\\.md$|\\.pdf$", "", basename(md)))
-            content <- gsub(src, tar, .readlines(md), fixed = TRUE)
-            writeLines(content, md)
-        }
+  # relative links
+  dn <- fs::path_join(c(path, "docs", "vignettes"))
+  if (fs::dir_exists(dn)) {
+    md_files <- fs::dir_ls(dn, regexp = "\\.md$")
+    for (md in md_files) {
+      src <- sprintf('src="%s.markdown_strict_files', gsub("\\.md$|\\.pdf$", "", basename(md)))
+      tar <- sprintf('src="vignettes/%s.markdown_strict_files', gsub("\\.md$|\\.pdf$", "", basename(md)))
+      content <- gsub(src, tar, .readlines(md), fixed = TRUE)
+      writeLines(content, md)
     }
+  }
 
-    # body also includes altdoc variables
-    fn <- fs::path_join(c(path, "altdoc", "docsify.html"))
-    body <- .readlines(fn)
-    body <- .substitute_altdoc_variables(body, path = path, tool = tool)
-    fn <- fs::path_join(c(.doc_path(path), "index.html"))
-    writeLines(body, fn)
+  # body also includes altdoc variables
+  fn <- fs::path_join(c(path, "altdoc", "docsify.html"))
+  body <- .readlines(fn)
+  body <- .substitute_altdoc_variables(body, path = path, tool = tool)
+  fn <- fs::path_join(c(.doc_path(path), "index.html"))
+  writeLines(body, fn)
 }
 
 
 .sidebar_vignettes_docsify <- function(sidebar, path) {
-    dn <- fs::path_join(c(.doc_path(path), "vignettes"))
-    fn_vignettes <- list.files(dn, pattern = "\\.md$|\\.pdf$", full.names = TRUE)
-    # before gsub on files
-    titles <- sapply(fn_vignettes, .get_vignettes_titles)
-    fn_vignettes <- sapply(fn_vignettes, function(x) {
-        fs::path_join(c("vignettes", basename(x)))
-    })
-    if (length(fn_vignettes) > 0) {
-        idx <- grep("\\$ALTDOC_VIGNETTE_BLOCK", sidebar)
-        if (length(idx) == 1) {
-            sidebar <- gsub("\\$ALTDOC_VIGNETTE_BLOCK", "", sidebar)
-            indent <- gsub("^(\\w*).*", "\\1", sidebar[idx])
-            tmp <- ifelse(
-                tools::file_ext(fn_vignettes) == "pdf",
-                sprintf("%s  - [%s](%s ':ignore')", indent, titles, fn_vignettes),
-                sprintf("%s  - [%s](%s)", indent, titles, fn_vignettes))
-            sidebar <- c(sidebar[1:idx], tmp, sidebar[(idx + 1):length(sidebar)])
-        }
-    } else {
-        sidebar <- sidebar[!grepl("\\$ALTDOC_VIGNETTE_BLOCK", sidebar)]
+  dn <- fs::path_join(c(.doc_path(path), "vignettes"))
+  fn_vignettes <- list.files(dn, pattern = "\\.md$|\\.pdf$", full.names = TRUE)
+  # before gsub on files
+  titles <- sapply(fn_vignettes, .get_vignettes_titles)
+  fn_vignettes <- sapply(fn_vignettes, function(x) {
+    fs::path_join(c("vignettes", basename(x)))
+  })
+  if (length(fn_vignettes) > 0) {
+    idx <- grep("\\$ALTDOC_VIGNETTE_BLOCK", sidebar)
+    if (length(idx) == 1) {
+      sidebar <- gsub("\\$ALTDOC_VIGNETTE_BLOCK", "", sidebar)
+      indent <- gsub("^(\\w*).*", "\\1", sidebar[idx])
+      tmp <- ifelse(
+        tools::file_ext(fn_vignettes) == "pdf",
+        sprintf("%s  - [%s](%s ':ignore')", indent, titles, fn_vignettes),
+        sprintf("%s  - [%s](%s)", indent, titles, fn_vignettes)
+      )
+      sidebar <- c(sidebar[1:idx], tmp, sidebar[(idx + 1):length(sidebar)])
     }
-    return(sidebar)
+  } else {
+    sidebar <- sidebar[!grepl("\\$ALTDOC_VIGNETTE_BLOCK", sidebar)]
+  }
+  return(sidebar)
 }
 
 
 .sidebar_man_docsify <- function(sidebar, path) {
-    dn <- fs::path_join(c(.doc_path(path), "man"))
-    if (fs::dir_exists(dn)) {
-        fn <- list.files(dn, pattern = "\\.md$", full.names = TRUE)
-        fn <- sapply(fn, function(x) fs::path_join(c("man", basename(x))))
-        fn <- sapply(fn, fs::path_ext_remove)
+  dn <- fs::path_join(c(.doc_path(path), "man"))
+  if (fs::dir_exists(dn)) {
+    fn <- list.files(dn, pattern = "\\.md$", full.names = TRUE)
+    fn <- sapply(fn, function(x) fs::path_join(c("man", basename(x))))
+    fn <- sapply(fn, fs::path_ext_remove)
 
-        if (length(fn) > 0) {
-            titles <- fs::path_ext_remove(basename(fn))
-            idx <- grep("\\$ALTDOC_MAN_BLOCK", sidebar)
-            if (length(idx) == 1) {
-                sidebar <- gsub("\\$ALTDOC_MAN_BLOCK", "", sidebar)
-                indent <- gsub("^(\\w*).*", "\\1", sidebar[idx])
-                tmp <- sprintf("%s  - [%s](%s)", indent, titles, fn)
-                sidebar <- c(sidebar[1:idx], tmp, sidebar[(idx + 1):length(sidebar)])
-            } else {
-                sidebar <- sidebar[!grepl("\\$ALTDOC_MAN_BLOCK", sidebar)]
-            }
-        } else {
-            sidebar <- sidebar[!grepl("\\$ALTDOC_MAN_BLOCK", sidebar)]
-        }
-    } else {
+    if (length(fn) > 0) {
+      titles <- fs::path_ext_remove(basename(fn))
+      idx <- grep("\\$ALTDOC_MAN_BLOCK", sidebar)
+      if (length(idx) == 1) {
+        sidebar <- gsub("\\$ALTDOC_MAN_BLOCK", "", sidebar)
+        indent <- gsub("^(\\w*).*", "\\1", sidebar[idx])
+        tmp <- sprintf("%s  - [%s](%s)", indent, titles, fn)
+        sidebar <- c(sidebar[1:idx], tmp, sidebar[(idx + 1):length(sidebar)])
+      } else {
         sidebar <- sidebar[!grepl("\\$ALTDOC_MAN_BLOCK", sidebar)]
+      }
+    } else {
+      sidebar <- sidebar[!grepl("\\$ALTDOC_MAN_BLOCK", sidebar)]
     }
-    return(sidebar)
+  } else {
+    sidebar <- sidebar[!grepl("\\$ALTDOC_MAN_BLOCK", sidebar)]
+  }
+  return(sidebar)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,7 +1,6 @@
 # https://github.com/ropenscilabs/r2readthedocs/blob/main/R/utils.R
 .convert_path <- function(path = ".") {
   path <- fs::path_abs(path)
-  .check_is_package(path = path)
   path <- normalizePath(path)
   return(path)
 }
@@ -89,10 +88,18 @@
     )
   }
 
-  if (mkdocs) return("mkdocs")
-  if (docsify) return("docsify")
-  if (docute) return("docute")
-  if (quarto_website) return("quarto_website")
+  if (mkdocs) {
+    return("mkdocs")
+  }
+  if (docsify) {
+    return("docsify")
+  }
+  if (docute) {
+    return("docute")
+  }
+  if (quarto_website) {
+    return("quarto_website")
+  }
 
   return(NULL)
 }
@@ -141,7 +148,8 @@
       "urls:",
       paste("  reference:", man),
       paste("  article:", vig),
-      "")
+      ""
+    )
     cli::cli_alert_info("Adding altdoc/pkgdown.yml file.")
     writeLines(content, fn)
   }

--- a/man/render_docs.Rd
+++ b/man/render_docs.Rd
@@ -4,16 +4,31 @@
 \alias{render_docs}
 \title{Update documentation}
 \usage{
-render_docs(path = ".", verbose = FALSE, parallel = FALSE, freeze = FALSE, ...)
+render_docs(
+  path = ".",
+  verbose = FALSE,
+  parallel = FALSE,
+  freeze = FALSE,
+  output_path = ".",
+  ...
+)
 }
 \arguments{
 \item{path}{Path to the package root directory.}
 
 \item{verbose}{Logical. Print Rmarkdown or Quarto rendering output.}
 
-\item{parallel}{Logical. Render man pages and vignettes in parallel using the \code{future} framework. In addition to setting this argument to TRUE, users must define the parallelism plan in \code{future}. See the examples section below.}
+\item{parallel}{Logical. Render man pages and vignettes in parallel using
+the \code{future} framework. In addition to setting this argument to TRUE, users
+must define the parallelism plan in \code{future}. See the examples section below.}
 
-\item{freeze}{Logical. If TRUE and a man page or vignette has not changed since the last call to \code{render_docs()}, that file is skipped. File hashes are stored in \code{altdoc/freeze.rds}. If that file is deleted, all man pages and vignettes will be rendered anew.}
+\item{freeze}{Logical. If TRUE and a man page or vignette has not changed
+since the last call to \code{render_docs()}, that file is skipped. File hashes
+are stored in \code{altdoc/freeze.rds}. If that file is deleted, all man pages
+and vignettes will be rendered anew.}
+
+\item{output_path}{Destination path for the documentation. For instance,
+specifying \code{output_path = "foo"} will write the documentation in \code{foo/docs}.}
 
 \item{...}{Additional arguments are ignored.}
 }
@@ -110,13 +125,11 @@ Importantly, \code{downlit} requires the \code{pkgdown.yml} file to be live on t
 
 \examples{
 if (interactive()) {
-
   render_docs()
 
   # parallel rendering
   library(future)
   plan(multicore)
   render_docs(parallel = TRUE)
-
 }
 }

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -50,7 +50,7 @@ create_local_thing <- function(
     thing = c("package", "project")) {
   thing <- match.arg(thing)
   if (fs::dir_exists(dir)) {
-    ui_stop("Target {ui_code('dir')} {.file {dir}} already exists.")
+    ui_stop("Target {ui_code('dir')} '{dir}' already exists.")
   }
 
   old_project <- proj_get_() # this could be `NULL`, i.e. no active project

--- a/tests/testthat/test-render_docs.R
+++ b/tests/testthat/test-render_docs.R
@@ -167,10 +167,13 @@ test_that("quarto: autolink", {
 test_that("arg 'output_path' works", {
   parent_dir <- withr::local_tempfile()
   create_local_package(dir = parent_dir)
-  fs::dir_create(fs::path("..", "docs"))
+  fs::dir_create(fs::path("..", "foobar"))
 
   setup_docs("docute")
-  render_docs(output_path = "../docs")
+  render_docs(output_path = "../foobar", verbose = .on_ci())
+
+  expect_false(dir_exists("docs"))
+  expect_true(dir_exists("../foobar/docs"))
 })
 
 

--- a/tests/testthat/test-render_docs.R
+++ b/tests/testthat/test-render_docs.R
@@ -164,6 +164,15 @@ test_that("quarto: autolink", {
   expect_true(any(grepl("https://rdrr.io/r/base/library.html", tmp, fixed = TRUE)))
 })
 
+test_that("arg 'output_path' works", {
+  parent_dir <- withr::local_tempfile()
+  create_local_package(dir = parent_dir)
+  fs::dir_create(fs::path("..", "docs"))
+
+  setup_docs("docute")
+  render_docs(output_path = "../docs")
+})
+
 
 # Test failures ------------------------------
 


### PR DESCRIPTION
Fixes https://github.com/etiennebacher/altdoc/issues/299

Bunch of auto-formatting changes, the actual changes are at the end of `render_docs()`. Instead of changing the target directory in all internal functions, I just cut and paste the "docs" folder to wherever the output path is.

@nsheff Could you try this branch and let me know if that works? 
```r
pak::pak("etiennebacher/altdoc#300")
```
Note that with this PR, the output folder is still be named "docs", so `render_docs(output_path = "../mydocs")` creates `.../mydocs/docs`. Is this what you had in mind or did you expect `../mydocs` to contain all the documentation files?