### PR TITLE
Fix and tests for different types of README when `tool = "quarto_website"`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,6 +35,7 @@ Suggests:
     future,
     future.apply,
     knitr,
+    patrick,
     servr,
     spelling,
     testthat (>= 3.0.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,6 @@ Suggests:
     future,
     future.apply,
     knitr,
-    patrick,
     servr,
     spelling,
     testthat (>= 3.0.0),

--- a/R/import_readme.R
+++ b/R/import_readme.R
@@ -60,10 +60,17 @@
 
     # Add the index page which includes README.md
     if (tool == "quarto_website") {
-        writeLines(
-            enc2utf8("{{< include README.md >}}"),
-            fs::path_join(c(tar_dir, "index.md"))
-        )
+        if ("README.qmd" %in% readme_files) {
+            fs::file_copy(
+                fs::path_join(c(src_dir, "README.qmd")),
+                fs::path_join(c(tar_dir, "index.qmd"))
+            )
+        } else {
+            writeLines(
+                enc2utf8("{{< include README.md >}}"),
+                fs::path_join(c(tar_dir, "index.md"))
+            )
+        }
     }
 
     tmp <- fs::path_join(c(src_dir, "README.markdown_strict_files"))

--- a/R/import_readme.R
+++ b/R/import_readme.R
@@ -53,29 +53,17 @@
         }
     }
 
-    if (tool == "quarto_website") {
-        tar_file <- fs::path_join(c(tar_dir, "index.md"))
-    } else {
-        tar_file <- fs::path_join(c(tar_dir, "README.md"))
-    }
+    tar_file <- fs::path_join(c(tar_dir, "README.md"))
     src_file <- fs::path_join(c(src_dir, "README.md"))
     fs::file_copy(src_file, tar_file, overwrite = TRUE)
     .check_md_structure(tar_file)
 
     # Add the index page which includes README.md
     if (tool == "quarto_website") {
-        if ("README.qmd" %in% readme_files) {
-            fs::file_copy(
-                fs::path_join(c(src_dir, "README.qmd")),
-                fs::path_join(c(tar_dir, "index.qmd"))
-            )
-        } else {
-            writeLines(
-                enc2utf8("{{< include README.md >}}"),
-                fs::path_join(c(tar_dir, "index.md"))
-            )
-            fs::file_copy(fs::path_join(c(src_dir, "README.md")), tar_dir)
-        }
+        writeLines(
+            enc2utf8("{{< include README.md >}}"),
+            fs::path_join(c(tar_dir, "index.md"))
+        )
     }
 
     tmp <- fs::path_join(c(src_dir, "README.markdown_strict_files"))

--- a/tests/testthat/test-render_docs.R
+++ b/tests/testthat/test-render_docs.R
@@ -194,8 +194,6 @@ for (tool in c("docute", "docsify", "quarto_website")) {
 test_that("quarto: autolink", {
     skip_on_cran()
 
-    print(here::here())
-
     ### setup: create a temp package using the structure of testpkg.altdoc
     path_to_example_pkg <- fs::path_abs(test_path("examples/testpkg.altdoc"))
     create_local_project()

--- a/tests/testthat/test-render_docs.R
+++ b/tests/testthat/test-render_docs.R
@@ -172,26 +172,30 @@ test_that("quarto: no error for basic workflow, no Github URL", {
     expect_no_error(render_docs(verbose = .on_ci()))
 })
 
-test_that("quarto: no error with different types of README", {
-    skip_on_cran()
-    create_local_package()
+patrick::with_parameters_test_that(
+    "quarto: no error with different types of README",
+    {
+        skip_on_cran()
+        create_local_package()
 
-    # README.md
-    cat("hello there", file = "README.md")
-    setup_docs("quarto_website")
-    expect_no_error(render_docs(verbose = .on_ci()))
-    fs::dir_delete("docs")
+        # README.md
+        cat("hello there", file = "README.md")
+        setup_docs(tool)
+        expect_no_error(render_docs(verbose = .on_ci()))
+        fs::dir_delete("docs")
 
-    # README.Rmd
-    cat("hello there", file = "README.Rmd")
-    expect_no_error(render_docs(verbose = .on_ci()))
-    fs::dir_delete("docs")
-    fs::file_delete("README.Rmd")
+        # README.Rmd
+        cat("hello there", file = "README.Rmd")
+        expect_no_error(render_docs(verbose = .on_ci()))
+        fs::dir_delete("docs")
+        fs::file_delete("README.Rmd")
 
-    # README.qmd
-    cat("hello there", file = "README.qmd")
-    expect_no_error(render_docs(verbose = .on_ci()))
-})
+        # README.qmd
+        cat("hello there", file = "README.qmd")
+        expect_no_error(render_docs(verbose = .on_ci()))
+    },
+    tool = c("docute", "docsify", "quarto_website")
+)
 
 test_that("quarto: autolink", {
     skip_on_cran()

--- a/tests/testthat/test-render_docs.R
+++ b/tests/testthat/test-render_docs.R
@@ -1,5 +1,6 @@
 test_that("docute: main files are correct", {
     skip_on_cran()
+    skip_if(.is_windows() && .on_ci(), "Windows on CI")
 
     ### setup: create a temp package using the structure of testpkg.altdoc
     path_to_example_pkg <- fs::path_abs(test_path("examples/testpkg.altdoc"))
@@ -36,6 +37,7 @@ test_that("docute: main files are correct", {
 
 test_that("docsify: main files are correct", {
     skip_on_cran()
+    skip_if(.is_windows() && .on_ci(), "Windows on CI")
 
     ### setup: create a temp package using the structure of testpkg.altdoc
     path_to_example_pkg <- fs::path_abs(test_path("examples/testpkg.altdoc"))
@@ -118,6 +120,7 @@ test_that("mkdocs: main files are correct", {
 
 test_that("quarto: no error for basic workflow", {
     skip_on_cran()
+    skip_if(.is_windows() && .on_ci(), "Windows on CI")
 
     ### setup: create a temp package using the structure of testpkg.altdoc
     path_to_example_pkg <- fs::path_abs(test_path("examples/testpkg.altdoc"))
@@ -149,6 +152,7 @@ test_that("quarto: no error for basic workflow", {
 # https://github.com/etiennebacher/altdoc/issues/307
 test_that("quarto: no error for basic workflow, no Github URL", {
     skip_on_cran()
+    skip_if(.is_windows() && .on_ci(), "Windows on CI")
 
     ### setup: create a temp package using the structure of testpkg.altdoc.noURL
     path_to_example_pkg <- fs::path_abs(
@@ -171,6 +175,7 @@ test_that("quarto: no error for basic workflow, no Github URL", {
 for (tool in c("docute", "docsify", "quarto_website")) {
     test_that("no error with different types of README", {
         skip_on_cran()
+        skip_if(.is_windows() && .on_ci(), "Windows on CI")
         create_local_package()
 
         # README.md
@@ -193,6 +198,7 @@ for (tool in c("docute", "docsify", "quarto_website")) {
 
 test_that("quarto: autolink", {
     skip_on_cran()
+    skip_if(.is_windows() && .on_ci(), "Windows on CI")
 
     ### setup: create a temp package using the structure of testpkg.altdoc
     path_to_example_pkg <- fs::path_abs(test_path("examples/testpkg.altdoc"))

--- a/tests/testthat/test-render_docs.R
+++ b/tests/testthat/test-render_docs.R
@@ -173,7 +173,7 @@ test_that("quarto: no error for basic workflow, no Github URL", {
 })
 
 patrick::with_parameters_test_that(
-    "quarto: no error with different types of README",
+    "no error with different types of README",
     {
         skip_on_cran()
         create_local_package()

--- a/tests/testthat/test-render_docs.R
+++ b/tests/testthat/test-render_docs.R
@@ -1,6 +1,5 @@
 test_that("docute: main files are correct", {
     skip_on_cran()
-    skip_if(.is_windows() && .on_ci(), "Windows on CI")
 
     ### setup: create a temp package using the structure of testpkg.altdoc
     path_to_example_pkg <- fs::path_abs(test_path("examples/testpkg.altdoc"))
@@ -37,7 +36,6 @@ test_that("docute: main files are correct", {
 
 test_that("docsify: main files are correct", {
     skip_on_cran()
-    skip_if(.is_windows() && .on_ci(), "Windows on CI")
 
     ### setup: create a temp package using the structure of testpkg.altdoc
     path_to_example_pkg <- fs::path_abs(test_path("examples/testpkg.altdoc"))
@@ -120,7 +118,6 @@ test_that("mkdocs: main files are correct", {
 
 test_that("quarto: no error for basic workflow", {
     skip_on_cran()
-    skip_if(.is_windows() && .on_ci(), "Windows on CI")
 
     ### setup: create a temp package using the structure of testpkg.altdoc
     path_to_example_pkg <- fs::path_abs(test_path("examples/testpkg.altdoc"))
@@ -152,7 +149,6 @@ test_that("quarto: no error for basic workflow", {
 # https://github.com/etiennebacher/altdoc/issues/307
 test_that("quarto: no error for basic workflow, no Github URL", {
     skip_on_cran()
-    skip_if(.is_windows() && .on_ci(), "Windows on CI")
 
     ### setup: create a temp package using the structure of testpkg.altdoc.noURL
     path_to_example_pkg <- fs::path_abs(
@@ -172,9 +168,8 @@ test_that("quarto: no error for basic workflow, no Github URL", {
     expect_no_error(render_docs(verbose = .on_ci()))
 })
 
-patrick::with_parameters_test_that(
-    "no error with different types of README",
-    {
+for (tool in c("docute", "docsify", "quarto_website")) {
+    test_that("no error with different types of README", {
         skip_on_cran()
         create_local_package()
 
@@ -193,13 +188,13 @@ patrick::with_parameters_test_that(
         # README.qmd
         cat("hello there", file = "README.qmd")
         expect_no_error(render_docs(verbose = .on_ci()))
-    },
-    tool = c("docute", "docsify", "quarto_website")
-)
+    })
+}
 
 test_that("quarto: autolink", {
     skip_on_cran()
-    skip_if(.is_windows() && .on_ci(), "Windows on CI")
+
+    print(here::here())
 
     ### setup: create a temp package using the structure of testpkg.altdoc
     path_to_example_pkg <- fs::path_abs(test_path("examples/testpkg.altdoc"))

--- a/tests/testthat/test-render_docs.R
+++ b/tests/testthat/test-render_docs.R
@@ -172,6 +172,27 @@ test_that("quarto: no error for basic workflow, no Github URL", {
     expect_no_error(render_docs(verbose = .on_ci()))
 })
 
+test_that("quarto: no error with different types of README", {
+    skip_on_cran()
+    create_local_package()
+
+    # README.md
+    cat("hello there", file = "README.md")
+    setup_docs("quarto_website")
+    expect_no_error(render_docs(verbose = .on_ci()))
+    fs::dir_delete("docs")
+
+    # README.Rmd
+    cat("hello there", file = "README.Rmd")
+    expect_no_error(render_docs(verbose = .on_ci()))
+    fs::dir_delete("docs")
+    fs::file_delete("README.Rmd")
+
+    # README.qmd
+    cat("hello there", file = "README.qmd")
+    expect_no_error(render_docs(verbose = .on_ci()))
+})
+
 test_that("quarto: autolink", {
     skip_on_cran()
     skip_if(.is_windows() && .on_ci(), "Windows on CI")


### PR DESCRIPTION
Depending on the type of README there were some errors when creating a quarto website