### PR TITLE
fix: Correctly reset `index.html` in `render_docs()` 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # News
 
+## Development version
+
+### Bug fixes
+
+* When using `mkdocs` as documentation generator, changes in settings such as
+  overrides templates or CSS files are now correctly applied to `docs/index.html`.
+  Previously, it was required to manually delete the file and run `render_docs()`
+  again (#337).
+
 ## 0.6.0
 
 ### Changes

--- a/R/settings_mkdocs.R
+++ b/R/settings_mkdocs.R
@@ -60,7 +60,7 @@
     }
     yaml::write_yaml(yml, fn, indent.mapping.sequence = TRUE)
 
-    fn <- fs::path_join(c(path, "index.html"))
+    fn <- fs::path_join(c(path, "docs", "index.html"))
     if (fs::file_exists(fn)) {
         fs::file_delete(fn)
     }


### PR DESCRIPTION
Fixes #336 