### PR TITLE
Remove second copy of license paragraph, re-render Rd

### DIFF
--- a/R/render_docs.R
+++ b/R/render_docs.R
@@ -26,8 +26,6 @@
 #'   - CODE_OF_CONDUCT.md, CODE_OF_CONDUCT.txt, CODE_OF_CONDUCT
 #' * `docs/LICENSE.md`
 #'   - LICENSE.md, LICENSE.txt, LICENSE
-#' * `docs/LICENCE.md`
-#'   - LICENCE.md, LICENCE.txt, LICENCE
 #'
 #' @return NULL
 #' @template altdoc_variables

--- a/man/render_docs.Rd
+++ b/man/render_docs.Rd
@@ -46,10 +46,6 @@ This function searches the root directory and the \verb{inst/} directory for spe
 \itemize{
 \item LICENSE.md, LICENSE.txt, LICENSE
 }
-\item \code{docs/LICENCE.md}
-\itemize{
-\item LICENCE.md, LICENCE.txt, LICENCE
-}
 }
 }
 \section{Altdoc variables}{


### PR DESCRIPTION
While reading `?render_docs` I noticed a duplicated paragraph about the license entry.  This PR removes it from the .R file and the re-rendered .Rd file.