### PR TITLE
handling `vignettes/articles` subfolder and custom sidebars

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,6 +46,6 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Language: en-US
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,6 +46,6 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
+RoxygenNote: 7.3.2
 Language: en-US
 VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,12 @@
 
 ### Bug fixes
 
+* Vignettes in subfolders (e.g., `vignettes/articles/`) are now discovered 
+  recursively when using `quarto_website`. (#355)
+
+* Custom sidebars with singleton entries in `quarto_website.yml` are now 
+  properly processed. (#355)
+
 * In 0.5.0, we announced that `README.qmd` wouldn't be automatically rendered,
   but this still happened when `output = "quarto_website"`. This is now fixed,
   meaning that `altdoc` uses `README.md` over `README.qmd` (#354).

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## 0.7.2
 
+* `quarto_website` now stages files pulled in by `{{< include >}}` directives
+  that resolve outside the copied source trees (e.g. a shared `macros/macros.qmd`
+  submodule at the package root), so those includes resolve at render time.
+
 * Disabled more tests on CRAN following a removal from CRAN due to a `NOTE` (#359).
 
 ## 0.7.1

--- a/R/settings_quarto_website.R
+++ b/R/settings_quarto_website.R
@@ -43,7 +43,8 @@
         input = fs::path_join(c(path, "_quarto")),
         quiet = !verbose,
         as_job = FALSE,
-        use_freezer = freeze
+        use_freezer = freeze,
+        quarto_args = if (verbose) " --log-level debug"
     )
 
     if (verbose) cli::cli_inform("finished `quarto::quarto_render()`")

--- a/R/settings_quarto_website.R
+++ b/R/settings_quarto_website.R
@@ -16,9 +16,7 @@
         indent.mapping.sequence = TRUE,
         handler = list(logical = yaml::verbatim_logical)
     )
-    if (verbose) {
-        cat(settings)
-    }
+    if (verbose) cat(settings)
     settings <- strsplit(settings, "\\n")[[1]]
     writeLines(settings, fs::path_join(c(path, "_quarto", "_quarto.yml")))
 
@@ -46,7 +44,6 @@
         use_freezer = freeze
     )
 
-    if (verbose) cli::cli_inform("finished `quarto::quarto_render()`")
     # copy the content of altdoc/ to docs/. This is important because the
     # process above rendered the site in a completely different directory, so
     # did not have the static files, and we want the static files in altdoc/ to

--- a/R/settings_quarto_website.R
+++ b/R/settings_quarto_website.R
@@ -43,8 +43,7 @@
         input = fs::path_join(c(path, "_quarto")),
         quiet = !verbose,
         as_job = FALSE,
-        use_freezer = freeze,
-        quarto_args = if (verbose) " --log-level debug"
+        use_freezer = freeze
     )
 
     if (verbose) cli::cli_inform("finished `quarto::quarto_render()`")

--- a/R/settings_quarto_website.R
+++ b/R/settings_quarto_website.R
@@ -16,6 +16,9 @@
         indent.mapping.sequence = TRUE,
         handler = list(logical = yaml::verbatim_logical)
     )
+    if (verbose) {
+        cat(settings)
+    }
     settings <- strsplit(settings, "\\n")[[1]]
     writeLines(settings, fs::path_join(c(path, "_quarto", "_quarto.yml")))
 

--- a/R/settings_quarto_website.R
+++ b/R/settings_quarto_website.R
@@ -57,7 +57,8 @@
     fn_vignettes <- list.files(
         fs::path_join(c(path, "_quarto/vignettes")),
         pattern = "\\.qmd$|\\.Rmd|\\.pdf$",
-        full.names = TRUE
+        full.names = TRUE,
+        recursive = TRUE
     )
     fn_man <- list.files(
         fs::path_join(c(path, "_quarto/man")),

--- a/R/settings_quarto_website.R
+++ b/R/settings_quarto_website.R
@@ -43,6 +43,7 @@
         use_freezer = freeze
     )
 
+    if (verbose) cli::cli_inform("finished `quarto::quarto_render()`")
     # copy the content of altdoc/ to docs/. This is important because the
     # process above rendered the site in a completely different directory, so
     # did not have the static files, and we want the static files in altdoc/ to

--- a/R/settings_quarto_website.R
+++ b/R/settings_quarto_website.R
@@ -71,7 +71,7 @@
     fn_vignettes <- gsub(".*_quarto.", "", fn_vignettes)
 
     yml <- paste(sidebar, collapse = "\n")
-    yml <- yaml::yaml.load(yml)
+    yml <- yaml::yaml.load(yml, handlers = list(seq = function(x) as.list(x)))
 
     # reverse order because we delete elements
     for (i in rev(seq_along(yml$website$sidebar$contents))) {

--- a/R/settings_quarto_website.R
+++ b/R/settings_quarto_website.R
@@ -16,7 +16,6 @@
         indent.mapping.sequence = TRUE,
         handler = list(logical = yaml::verbatim_logical)
     )
-    if (verbose) cat(settings)
     settings <- strsplit(settings, "\\n")[[1]]
     writeLines(settings, fs::path_join(c(path, "_quarto", "_quarto.yml")))
 

--- a/R/settings_quarto_website.R
+++ b/R/settings_quarto_website.R
@@ -35,6 +35,15 @@
     # Clear out `tar`
     fs::file_delete(files)
 
+    # Stage files pulled in by `{{< include >}}` directives that live outside
+    # the copied source trees (e.g. a shared `macros/macros.qmd` submodule at
+    # the package root). Quarto resolves include paths relative to the
+    # including file, so these must exist under `_quarto/` before rendering.
+    .stage_external_includes(
+        src_dir = path,
+        quarto_dir = fs::path_join(c(path, "_quarto"))
+    )
+
     # render to `output-dir: ../docs/`
     quarto::quarto_render(
         input = fs::path_join(c(path, "_quarto")),
@@ -143,4 +152,73 @@
         }
     }
     return(sidebar)
+}
+
+# Copy files referenced by Quarto `{{< include >}}` directives that resolve to
+# a location outside the `_quarto/` build tree into the matching spot under
+# `_quarto/`, so Quarto can find them at render time.
+#
+# altdoc stages `vignettes/`, `man/`, and the miscellaneous root files into
+# `_quarto/`, but an include such as `{{< include ../macros/macros.qmd >}}`
+# (common when a package shares its LaTeX macros via a submodule at the package
+# root) points outside those trees and is otherwise never copied. Because
+# Quarto resolves include paths relative to the including file, the referenced
+# file must live at the same relative path under `_quarto/`. This walks the
+# staged files, follows their includes recursively, and copies each
+# externally-referenced file from the source tree into `_quarto/`.
+.stage_external_includes <- function(src_dir, quarto_dir) {
+    src_dir <- fs::path_abs(src_dir)
+    quarto_dir <- fs::path_abs(quarto_dir)
+    include_re <- "\\{\\{<\\s*include\\s+([^>]+?)\\s*>\\}\\}"
+
+    queue <- list.files(
+        quarto_dir,
+        pattern = "\\.qmd$|\\.Rmd$|\\.md$",
+        full.names = TRUE,
+        recursive = TRUE
+    )
+    seen <- character(0)
+
+    while (length(queue) > 0) {
+        fn <- queue[[1]]
+        queue <- queue[-1]
+        if (fn %in% seen || !fs::file_exists(fn)) {
+            next
+        }
+        seen <- c(seen, fn)
+
+        matches <- regmatches(
+            .readlines(fn),
+            regexpr(include_re, .readlines(fn))
+        )
+        paths <- sub(include_re, "\\1", matches)
+        for (inc in unique(trimws(paths))) {
+            inc <- gsub('^["\']|["\']$', "", inc)
+
+            # only includes that escape the copied tree need staging; the rest
+            # were already copied with their containing directory
+            if (!grepl("\\.\\.", inc)) {
+                next
+            }
+
+            rel <- fs::path_rel(
+                fs::path_norm(fs::path_join(c(fs::path_dir(fn), inc))),
+                start = quarto_dir
+            )
+            tar_file <- fs::path_join(c(quarto_dir, rel))
+            src_file <- fs::path_join(c(src_dir, rel))
+
+            if (fs::file_exists(tar_file)) {
+                queue <- c(queue, tar_file)
+                next
+            }
+            if (fs::file_exists(src_file)) {
+                fs::dir_create(fs::path_dir(tar_file))
+                fs::file_copy(src_file, tar_file, overwrite = TRUE)
+                queue <- c(queue, tar_file)
+            }
+        }
+    }
+
+    invisible()
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -22,13 +22,6 @@
     fs::dir_exists(venv_path)
 }
 
-# https://stackoverflow.com/a/42945293/11598948
-.stop_quietly <- function() {
-    opt <- options(show.error.messages = FALSE)
-    on.exit(options(opt))
-    stop()
-}
-
 .folder_is_empty <- function(x) {
     length(list.files(x)) == 0
 }

--- a/jarl.toml
+++ b/jarl.toml
@@ -1,0 +1,6 @@
+[lint]
+# Fixture packages copied and rendered as test data; their functions are
+# never meant to be called by altdoc's own code. `per-file-ignores` (which
+# would scope this to just `unused_function`) isn't supported by the jarl
+# version this repo's CI installs, so exclude the whole directory instead.
+exclude = ["tests/testthat/examples/"]

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -2,25 +2,11 @@ library(fs)
 library(usethis)
 library(withr)
 
-### Don't run mkdocs in other places than my laptop
-### It requires installing pip3 and mkdocs, which is not possible on CRAN
-### (to my knowledge)
-skip_mkdocs <- function() {
-    skip_on_cran()
-    skip_if_not(.venv_exists())
-}
-
 ### Taken from {usethis} (file "R/project.R")
 
 proj <- new.env(parent = emptyenv())
 
 proj_get_ <- function() proj$cur
-
-proj_set_ <- function(path) {
-    old <- proj$cur
-    proj$cur <- path
-    invisible(old)
-}
 
 ### Taken from {usethis} (file "tests/testthat/helper.R")
 
@@ -92,5 +78,3 @@ create_local_thing <- function(
 
     invisible(usethis::proj_get())
 }
-
-expect_proj_file <- function(...) expect_true(fs::file_exists(proj_path(...)))

--- a/tests/testthat/test-settings_quarto_website.R
+++ b/tests/testthat/test-settings_quarto_website.R
@@ -1,0 +1,67 @@
+test_that(".stage_external_includes() stages includes that escape the tree", {
+    root <- withr::local_tempdir()
+
+    # source tree: a shared macros file outside vignettes/, referenced via `..`
+    fs::dir_create(fs::path_join(c(root, "macros")))
+    writeLines("MACROS", fs::path_join(c(root, "macros", "macros.qmd")))
+
+    # `_quarto/` tree as altdoc assembles it before rendering
+    vig <- fs::path_join(c(root, "_quarto", "vignettes"))
+    fs::dir_create(fs::path_join(c(vig, "articles")))
+    writeLines(
+        c(
+            "{{< include ../macros/macros.qmd >}}",
+            "{{< include articles/_local.qmd >}}"
+        ),
+        fs::path_join(c(vig, "methodology.qmd"))
+    )
+    # an in-tree include, already staged with its directory
+    writeLines("LOCAL", fs::path_join(c(vig, "articles", "_local.qmd")))
+
+    .stage_external_includes(
+        src_dir = root,
+        quarto_dir = fs::path_join(c(root, "_quarto"))
+    )
+
+    # the escaping include is copied to the path Quarto will resolve it to
+    staged <- fs::path_join(c(root, "_quarto", "macros", "macros.qmd"))
+    expect_true(fs::file_exists(staged))
+    expect_identical(.readlines(staged), "MACROS")
+
+    # the in-tree include is left where it already was, not re-staged elsewhere
+    expect_false(
+        fs::file_exists(fs::path_join(c(root, "_quarto", "articles", "_local.qmd")))
+    )
+})
+
+test_that(".stage_external_includes() follows nested includes recursively", {
+    root <- withr::local_tempdir()
+
+    fs::dir_create(fs::path_join(c(root, "macros")))
+    # macros.qmd itself pulls in a sibling via an escaping include
+    writeLines(
+        "{{< include ../shared/defs.qmd >}}",
+        fs::path_join(c(root, "macros", "macros.qmd"))
+    )
+    fs::dir_create(fs::path_join(c(root, "shared")))
+    writeLines("DEFS", fs::path_join(c(root, "shared", "defs.qmd")))
+
+    vig <- fs::path_join(c(root, "_quarto", "vignettes"))
+    fs::dir_create(vig)
+    writeLines(
+        "{{< include ../macros/macros.qmd >}}",
+        fs::path_join(c(vig, "methodology.qmd"))
+    )
+
+    .stage_external_includes(
+        src_dir = root,
+        quarto_dir = fs::path_join(c(root, "_quarto"))
+    )
+
+    expect_true(
+        fs::file_exists(fs::path_join(c(root, "_quarto", "macros", "macros.qmd")))
+    )
+    expect_true(
+        fs::file_exists(fs::path_join(c(root, "_quarto", "shared", "defs.qmd")))
+    )
+})


### PR DESCRIPTION
I hope it's ok to send this PR; feel free to close if not! 

I attempted fixes for two problems I ran into (reprex: https://github.com/UCD-SERG/rpt):

1. find .qmd files in the `vignettes/articles` subfolder (https://r-pkgs.org/vignettes.html#sec-vignettes-article)

2. include singleton entries in custom sidebars in preprocessed `_quarto.yml`

2b. Print the preprocessed `_quarto.yml` in verbose mode (helped diagnose 2)

Glad to revise as helpful, if this is of interest. Thanks for this awesome package!