### PR TITLE
Skip .qmd generation for .Rd files that didn't change.

### DIFF
--- a/R/import_man.R
+++ b/R/import_man.R
@@ -162,9 +162,12 @@
 
     # Skip file when frozen
     if (isTRUE(freeze)) {
+
+        freeze_output <- if (tool == "quarto_website") destination_qmd else destination_md
+
         flag <- .is_frozen(
             input = origin_Rd,
-            output = destination_md,
+            output = freeze_output,
             hashes = hashes
         )
         if (isTRUE(flag)) {

--- a/R/render_docs.R
+++ b/R/render_docs.R
@@ -89,8 +89,27 @@ render_docs <- function(
                     function(f) basename(f) != "_freeze",
                     docs_files
                 )
+                docs_files <- Filter(
+                    function(f) basename(f) != "man",
+                    docs_files
+                )
             }
             fs::file_delete(docs_files)
+
+            # When freeze is on, clean up stale man-page qmds with no matching .Rd
+            if (isTRUE(freeze)) {
+                man_dir <- fs::path_join(c(docs_dir, "man"))
+                if (fs::dir_exists(man_dir)) {
+                    rd_stems <- fs::path_ext_remove(basename(
+                        list.files(fs::path_join(c(path, "man")),
+                            pattern = "\\.Rd$"
+                        )
+                    ))
+                    old_qmds <- fs::dir_ls(man_dir, regexp = "\\.qmd$")
+                    stale <- old_qmds[!fs::path_ext_remove(basename(old_qmds)) %in% rd_stems]
+                    if (length(stale)) fs::file_delete(stale)
+                }
+            }
         }
     } else {
         docs_dir <- fs::path_join(c(path, "docs"))

--- a/tests/testthat/test-freeze-quarto.R
+++ b/tests/testthat/test-freeze-quarto.R
@@ -1,0 +1,47 @@
+library(testthat)
+library(altdoc)
+
+test_that("quarto: freeze skips man pages when unchanged", {
+    skip_on_cran()
+    skip_if(!.quarto_is_installed())
+
+    ### setup: create a temp package
+    create_local_package()
+    fs::dir_create("man")
+    cat(
+        "\\name{hi}\n\\title{hi}\n\\usage{\nhi()\n}\n\\description{hi}\n",
+        file = "man/hi.Rd"
+    )
+    cat(
+      "\\name{ho}\n\\title{ho}\n\\usage{\nho()\n}\n\\description{ho}\n",
+      file = "man/ho.Rd"
+    )
+
+    setup_docs("quarto_website")
+
+    # First run
+    render_docs(freeze = TRUE, verbose = FALSE)
+
+    expect_true(fs::file_exists("_quarto/man/ho.qmd"))
+    expect_true(fs::file_exists("docs/man/ho.html"))
+    expect_true(fs::file_exists("altdoc/freeze.rds"))
+
+    mtime1 <- fs::file_info("_quarto/man/hi.qmd")$modification_time
+
+    # Delete one of the .Rd files to check that cleanup works
+    fs::file_delete("man/ho.Rd")
+
+    # Second run
+    Sys.sleep(1.1) # Ensure time difference
+    out <- capture_messages(render_docs(freeze = TRUE, verbose = FALSE))
+
+    # Check that stale files are removed
+    expect_false(fs::file_exists("_quarto/man/ho.qmd"))
+    expect_false(fs::file_exists("docs/man/ho.html"))
+
+    # Check that re-generation was skipped
+    mtime2 <- fs::file_info("_quarto/man/hi.qmd")$modification_time
+    expect_equal(mtime1, mtime2)
+
+    expect_match(paste(out, collapse = "\n"), "1 .Rd files skipped because they didn't change")
+})


### PR DESCRIPTION
When I render the documentation website with quarto with `altdoc::render_docs(freeze = TRUE)` it re-processes all man pages even though none of them have changed. The mechanism for skipping the generation of new .qmd files for man pages whose .Rd file had not changed is not working. There are two issues:

1. Wrong output file extension in .is_frozen() call
2. render_docs() deletes _quarto/man/ before the freeze check can run

This pull request fixes both these issues.