### PR TITLE
Implement custom reference

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: altdoc
 Title: Package Documentation Websites with 'Quarto', 'Docsify', 'Docute', or 'MkDocs'
-Version: 0.7.3
+Version: 0.7.3.9000
 Authors@R:
     c(person(given = "Etienne",
              family = "Bacher",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # News
 
+## Development version
+
+* For `quarto_website`, functions can now be grouped and ordered on the
+  reference index page and sidebar by adding an `altdoc/reference.yml` file
+  (similar to `pkgdown`'s `_pkgdown.yml` reference section).
+
 ## 0.7.3
 
 * Fix NOTE in CRAN results.

--- a/R/reference_index.R
+++ b/R/reference_index.R
@@ -88,7 +88,13 @@
         )
     })
 
-    lines <- c('---', 'title: "Function reference"', '---', "", unlist(sections))
+    lines <- c(
+        '---',
+        'title: "Function reference"',
+        '---',
+        "",
+        unlist(sections)
+    )
     lines <- lines[-length(lines)] # drop trailing blank line
 
     out_dir <- fs::path_join(c(docs_dir, "man"))

--- a/R/reference_index.R
+++ b/R/reference_index.R
@@ -1,0 +1,97 @@
+.reference_yaml_path <- function(path) {
+    fs::path_join(c(path, "altdoc", "reference.yml"))
+}
+
+.read_reference_config <- function(path) {
+    fn <- .reference_yaml_path(path)
+    if (!fs::file_exists(fn)) {
+        return(NULL)
+    }
+    yaml::yaml.load_file(fn)
+}
+
+# Maps every \name{}/\alias{} documented in man/*.Rd to that Rd file's
+# basename (the name .render_one_man() uses for the rendered man/<basename>.qmd
+# target) and its \title{}, so `reference.yml` entries can refer to a
+# function by any of its aliases, not just its Rd filename.
+.rd_topic_index <- function(path) {
+    rd_files <- fs::dir_ls(fs::path_join(c(path, "man")), regexp = "\\.Rd$")
+
+    index <- list()
+    for (rd_file in rd_files) {
+        rd <- tools::parse_Rd(rd_file)
+        tags <- vapply(rd, function(x) attr(x, "Rd_tag"), character(1))
+        aliases <- vapply(
+            rd[tags == "\\alias"],
+            function(x) as.character(x[[1]]),
+            character(1)
+        )
+        title <- trimws(paste(unlist(rd[tags == "\\title"]), collapse = ""))
+        base <- fs::path_ext_remove(basename(rd_file))
+
+        for (alias in aliases) {
+            index[[alias]] <- list(basename = base, title = title)
+        }
+    }
+    index
+}
+
+# Errors if `reference.yml` lists a name with no matching Rd (typo, most
+# likely), and warns if some documented topic isn't listed anywhere in
+# `reference.yml` (it just won't appear on the index page).
+.validate_reference_config <- function(config, topics) {
+    listed <- unlist(lapply(config, function(block) block$contents))
+
+    missing_rd <- setdiff(listed, names(topics))
+    if (length(missing_rd) > 0) {
+        cli::cli_abort(
+            "altdoc/reference.yml lists {.val {missing_rd}}, which {?has/have} no matching \\name{{}}/\\alias{{}} in man/*.Rd."
+        )
+    }
+
+    unlisted <- setdiff(names(topics), listed)
+    if (length(unlisted) > 0) {
+        cli::cli_warn(
+            "man/*.Rd defines {.val {unlisted}}, which {?is/are} not listed in altdoc/reference.yml and won't appear on the reference index."
+        )
+    }
+
+    invisible(NULL)
+}
+
+.build_reference_index <- function(path, docs_dir) {
+    config <- .read_reference_config(path)
+    topics <- .rd_topic_index(path)
+    .validate_reference_config(config, topics)
+
+    sections <- lapply(config, function(block) {
+        entries <- vapply(
+            block$contents,
+            function(name) {
+                topic <- topics[[name]]
+                sprintf(
+                    '<dt><code><a href="%s.qmd">%s()</a></code></dt>\n<dd>%s</dd>',
+                    topic$basename,
+                    name,
+                    topic$title
+                )
+            },
+            character(1)
+        )
+        c(
+            paste0("## ", block$title),
+            "",
+            '<dl class="ref-index">',
+            paste(entries, collapse = "\n\n"),
+            "</dl>",
+            ""
+        )
+    })
+
+    lines <- c('---', 'title: "Function reference"', '---', "", unlist(sections))
+    lines <- lines[-length(lines)] # drop trailing blank line
+
+    out_dir <- fs::path_join(c(docs_dir, "man"))
+    fs::dir_create(out_dir)
+    writeLines(lines, fs::path_join(c(out_dir, "index.qmd")))
+}

--- a/R/render_docs.R
+++ b/R/render_docs.R
@@ -130,6 +130,11 @@ render_docs <- function(
         freeze = freeze
     )
 
+    # Only supported for quarto_website, and only if altdoc/reference.yml exists.
+    if (tool == "quarto_website" && fs::file_exists(.reference_yaml_path(path))) {
+        .build_reference_index(path, docs_dir)
+    }
+
     # Update vignettes
     cli::cli_h1("Vignettes")
     fail_vignettes <- .import_vignettes(

--- a/R/render_docs.R
+++ b/R/render_docs.R
@@ -131,7 +131,9 @@ render_docs <- function(
     )
 
     # Only supported for quarto_website, and only if altdoc/reference.yml exists.
-    if (tool == "quarto_website" && fs::file_exists(.reference_yaml_path(path))) {
+    if (
+        tool == "quarto_website" && fs::file_exists(.reference_yaml_path(path))
+    ) {
         .build_reference_index(path, docs_dir)
     }
 

--- a/R/settings_quarto_website.R
+++ b/R/settings_quarto_website.R
@@ -110,15 +110,35 @@
             )
         ) {
             if (length(fn_man) > 0) {
-                man_list <- lapply(
-                    fn_man,
-                    function(x) {
-                        list(
-                            text = sub("\\.qmd$", "", basename(x)),
-                            file = x
-                        )
-                    }
-                )
+                config <- .read_reference_config(path)
+                if (!is.null(config)) {
+                    topics <- .rd_topic_index(path)
+                    man_list <- c(
+                        list(list(text = "Overview", file = "man/index.qmd")),
+                        lapply(config, function(block) {
+                            list(
+                                section = block$title,
+                                contents = lapply(block$contents, function(name) {
+                                    topic <- topics[[name]]
+                                    list(
+                                        text = name,
+                                        file = paste0("man/", topic$basename, ".qmd")
+                                    )
+                                })
+                            )
+                        })
+                    )
+                } else {
+                    man_list <- lapply(
+                        fn_man,
+                        function(x) {
+                            list(
+                                text = sub("\\.qmd$", "", basename(x)),
+                                file = x
+                            )
+                        }
+                    )
+                }
                 yml$website$sidebar$contents[[i]] <- list(
                     section = "Reference",
                     contents = man_list

--- a/R/settings_quarto_website.R
+++ b/R/settings_quarto_website.R
@@ -118,13 +118,20 @@
                         lapply(config, function(block) {
                             list(
                                 section = block$title,
-                                contents = lapply(block$contents, function(name) {
-                                    topic <- topics[[name]]
-                                    list(
-                                        text = name,
-                                        file = paste0("man/", topic$basename, ".qmd")
-                                    )
-                                })
+                                contents = lapply(
+                                    block$contents,
+                                    function(name) {
+                                        topic <- topics[[name]]
+                                        list(
+                                            text = name,
+                                            file = paste0(
+                                                "man/",
+                                                topic$basename,
+                                                ".qmd"
+                                            )
+                                        )
+                                    }
+                                )
                             )
                         })
                     )

--- a/tests/testthat/_snaps/docsify/render_docs/index.html
+++ b/tests/testthat/_snaps/docsify/render_docs/index.html
@@ -28,7 +28,7 @@
       },
       plugins: [
         function(hook) {
-          var footer = ["<a > <code> testpkg.altdoc </code> v. 0.1.0 </a> | Documentation made with <a href='https://altdoc.etiennebacher.com/'> <code> altdoc </code> v. 0.7.3</a>"].join('');
+          var footer = ["<a > <code> testpkg.altdoc </code> v. 0.1.0 </a> | Documentation made with <a href='https://altdoc.etiennebacher.com/'> <code> altdoc </code> v. 0.7.3.9000</a>"].join('');
 
           hook.afterEach(function(html) {
             return html + footer;

--- a/tests/testthat/test-reference_index.R
+++ b/tests/testthat/test-reference_index.R
@@ -1,0 +1,134 @@
+test_that("quarto: reference.yml groups/orders the man index and sidebar", {
+    skip_on_cran()
+    skip_if(.is_windows() && .on_ci(), "Windows on CI")
+    skip_if(!.quarto_is_installed())
+
+    path_to_example_pkg <- fs::path_abs(test_path("examples/testpkg.altdoc"))
+    create_local_project()
+    fs::dir_delete("R")
+    fs::dir_copy(path_to_example_pkg, ".")
+    all_files <- list.files("testpkg.altdoc", full.names = TRUE)
+    for (i in all_files) {
+        fs::file_move(i, ".")
+    }
+    fs::dir_delete("testpkg.altdoc")
+
+    install.packages(".", repos = NULL, type = "source")
+    setup_docs("quarto_website")
+
+    writeLines(
+        c(
+            "- title: Greetings",
+            "  contents:",
+            "    - hello_base",
+            "    - hello_r6",
+            "- title: Conditional examples",
+            "  contents:",
+            "    - examplesIf_true",
+            "    - examplesIf_false"
+        ),
+        "altdoc/reference.yml"
+    )
+
+    expect_no_error(render_docs(verbose = .on_ci()))
+
+    ### the grouped index page was generated ...
+    expect_true(fs::file_exists("docs/man/index.html"))
+    index_html <- .readlines("docs/man/index.html")
+    expect_true(any(grepl("Greetings", index_html, fixed = TRUE)))
+    expect_true(any(grepl("Conditional examples", index_html, fixed = TRUE)))
+    # groups appear in the order given in reference.yml
+    expect_true(
+        grep("Greetings", index_html, fixed = TRUE)[1] <
+            grep("Conditional examples", index_html, fixed = TRUE)[1]
+    )
+    expect_true(any(grepl("hello_base", index_html, fixed = TRUE)))
+    expect_true(any(grepl("Base function", index_html, fixed = TRUE)))
+
+    ### ... and the sidebar reflects the same grouping
+    man_html <- .readlines("docs/man/hello_base.html")
+    expect_true(any(grepl("Greetings", man_html, fixed = TRUE)))
+    expect_true(any(grepl("Conditional examples", man_html, fixed = TRUE)))
+})
+
+test_that("quarto: reference.yml errors on unknown function names", {
+    skip_on_cran()
+    skip_if(.is_windows() && .on_ci(), "Windows on CI")
+    skip_if(!.quarto_is_installed())
+
+    path_to_example_pkg <- fs::path_abs(test_path("examples/testpkg.altdoc"))
+    create_local_project()
+    fs::dir_delete("R")
+    fs::dir_copy(path_to_example_pkg, ".")
+    all_files <- list.files("testpkg.altdoc", full.names = TRUE)
+    for (i in all_files) {
+        fs::file_move(i, ".")
+    }
+    fs::dir_delete("testpkg.altdoc")
+
+    install.packages(".", repos = NULL, type = "source")
+    setup_docs("quarto_website")
+
+    writeLines(
+        c(
+            "- title: Greetings",
+            "  contents:",
+            "    - not_a_real_function"
+        ),
+        "altdoc/reference.yml"
+    )
+
+    expect_error(render_docs(verbose = .on_ci()), "not_a_real_function")
+})
+
+test_that("quarto: reference.yml warns on undocumented topics", {
+    skip_on_cran()
+    skip_if(.is_windows() && .on_ci(), "Windows on CI")
+    skip_if(!.quarto_is_installed())
+
+    path_to_example_pkg <- fs::path_abs(test_path("examples/testpkg.altdoc"))
+    create_local_project()
+    fs::dir_delete("R")
+    fs::dir_copy(path_to_example_pkg, ".")
+    all_files <- list.files("testpkg.altdoc", full.names = TRUE)
+    for (i in all_files) {
+        fs::file_move(i, ".")
+    }
+    fs::dir_delete("testpkg.altdoc")
+
+    install.packages(".", repos = NULL, type = "source")
+    setup_docs("quarto_website")
+
+    writeLines(
+        c(
+            "- title: Greetings",
+            "  contents:",
+            "    - hello_base"
+        ),
+        "altdoc/reference.yml"
+    )
+
+    expect_warning(render_docs(verbose = .on_ci()), "hello_r6")
+})
+
+test_that("quarto: no reference.yml keeps the current flat/alphabetical behavior", {
+    skip_on_cran()
+    skip_if(.is_windows() && .on_ci(), "Windows on CI")
+    skip_if(!.quarto_is_installed())
+
+    path_to_example_pkg <- fs::path_abs(test_path("examples/testpkg.altdoc"))
+    create_local_project()
+    fs::dir_delete("R")
+    fs::dir_copy(path_to_example_pkg, ".")
+    all_files <- list.files("testpkg.altdoc", full.names = TRUE)
+    for (i in all_files) {
+        fs::file_move(i, ".")
+    }
+    fs::dir_delete("testpkg.altdoc")
+
+    install.packages(".", repos = NULL, type = "source")
+    setup_docs("quarto_website")
+
+    expect_no_error(render_docs(verbose = .on_ci()))
+    expect_false(fs::file_exists("docs/man/index.html"))
+})

--- a/vignettes/customize.qmd
+++ b/vignettes/customize.qmd
@@ -166,7 +166,24 @@ The Docute website hosts a detailed guide on customization. As with the other do
 
 * [Docute Customization Guide](https://docute.egoist.dev/guide/customization)
 
+## Quarto website
 
+For `quarto_website`, you can group and order functions on the reference index page and sidebar by adding an `altdoc/reference.yml` file. This works similarly to the `reference` section of `pkgdown`'s `_pkgdown.yml`.
+
+Create `altdoc/reference.yml`, listing functions (by name or alias) under section titles:
+
+```yaml
+- title: Main functions
+  contents:
+    - my_function
+    - my_other_function
+- title: Helpers
+  contents:
+    - helper_one
+    - helper_two
+```
+
+`altdoc` builds a grouped `man/index.qmd` overview page and reflects the same grouping and order in the sidebar. Every documented function must be listed in `altdoc/reference.yml`; `altdoc` errors on unknown names and warns about any documented function that is missing from the file. If `altdoc/reference.yml` does not exist, it uses a flat alphabetical layout.
 
 ## Pre and post-processing
 


### PR DESCRIPTION
Implements pkgdown like support for custom reference order, headers etc.

Only implemented for Quarto, since it's the only thing I use. I have no idea if it's trivial or not to extend to the other formats.

Used `altdoc/references.yml` as entry point with syntax equivalent to pkgdown.

Generated with the help of AI, and manually fixed and verified.

Ref #326 